### PR TITLE
fix(api): close cross-tenant write holes and make sessions revocable

### DIFF
--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -5,9 +5,10 @@ from drf_spectacular.views import (
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import TokenRefreshView
 
 from app.health import healthz
+from pft.views import LogoutView, ThrottledTokenObtainPairView
 
 urlpatterns = [
     path("healthz/", healthz, name="healthz"),
@@ -25,6 +26,7 @@ urlpatterns = [
     ),
     path("api/v1/", include(("pft.urls"), namespace="pft")),
     path("api/v1/finance/", include(("pft.finance_urls"), namespace="pft-finance")),
-    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/", ThrottledTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("api/token/logout/", LogoutView.as_view(), name="token_logout"),
 ]

--- a/api/pft/apps.py
+++ b/api/pft/apps.py
@@ -6,4 +6,6 @@ class PftConfig(AppConfig):
     name = "pft"
 
     def ready(self):
-        import pft.signals
+        # Imported for its side effects: registers the post_save receiver that
+        # seeds a new user's default budget file, account and categories.
+        from . import signals  # noqa: F401

--- a/api/pft/finance_serializers.py
+++ b/api/pft/finance_serializers.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from django.conf import settings
 from django.db import transaction
 from rest_framework import serializers
 
@@ -454,6 +455,15 @@ class EncryptedBackupBundleSerializer(serializers.ModelSerializer, UserOwnedBudg
         self._validate_budget_file_owner(value)
         return value
 
+    def validate_ciphertext(self, value):
+        """Cap the bundle size. The field is an unbounded TextField."""
+        max_bytes = settings.FINTRACK_MAX_BACKUP_BYTES
+        if value and len(value.encode("utf-8")) > max_bytes:
+            raise serializers.ValidationError(
+                f"Backup bundle exceeds the {max_bytes // 1024}KB limit."
+            )
+        return value
+
 
 class ImportJobSerializer(serializers.ModelSerializer, UserOwnedBudgetFileMixin):
     class Meta:
@@ -481,4 +491,18 @@ class ImportJobSerializer(serializers.ModelSerializer, UserOwnedBudgetFileMixin)
 
     def validate_budget_file(self, value):
         self._validate_budget_file_owner(value)
+        return value
+
+    def validate_source_payload(self, value):
+        """Cap the uploaded statement size.
+
+        The payload is stored as plaintext TEXT and parsed synchronously inside
+        the request, so an unbounded upload is both a memory and a storage
+        problem on a small self-hosted box.
+        """
+        max_bytes = settings.FINTRACK_MAX_IMPORT_BYTES
+        if value and len(value.encode("utf-8")) > max_bytes:
+            raise serializers.ValidationError(
+                f"Import payload exceeds the {max_bytes // 1024}KB limit."
+            )
         return value

--- a/api/pft/finance_services.py
+++ b/api/pft/finance_services.py
@@ -3,12 +3,12 @@ import csv
 import io
 import json
 import uuid
+import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from xml.sax.saxutils import escape as xml_escape
-import xml.etree.ElementTree as ET
 
 from django.db import transaction
 from django.db.models import Sum
@@ -158,6 +158,14 @@ def compute_spending_trends(budget_file: BudgetFile, start_date: date, end_date:
     }
 
 
+def _report_date(value, field_name):
+    """Parse a report date, turning malformed input into a clear ValueError."""
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a date in YYYY-MM-DD format.") from exc
+
+
 def run_report(budget_file: BudgetFile, payload: dict):
     report_type = payload.get("report_type", SavedReport.TYPE_CUSTOM)
 
@@ -166,17 +174,19 @@ def run_report(budget_file: BudgetFile, payload: dict):
     today = timezone.now().date()
 
     if start_date_value:
-        start_date = date.fromisoformat(start_date_value)
+        start_date = _report_date(start_date_value, "start_date")
     else:
         start_date = date(today.year, today.month, 1)
 
     if end_date_value:
-        end_date = date.fromisoformat(end_date_value)
+        end_date = _report_date(end_date_value, "end_date")
     else:
         end_date = today
 
     if report_type == SavedReport.TYPE_NET_WORTH:
-        as_of = date.fromisoformat(payload.get("as_of")) if payload.get("as_of") else end_date
+        as_of = (
+            _report_date(payload.get("as_of"), "as_of") if payload.get("as_of") else end_date
+        )
         return compute_net_worth(budget_file, as_of)
 
     if report_type == SavedReport.TYPE_CASH_FLOW:
@@ -653,11 +663,44 @@ def _validate_postings_balance(postings: list[dict]):
     return total == Decimal("0.00")
 
 
+def _validate_template_posting_targets(budget_file, postings: list[dict]):
+    """Ensure every account/category id in a template belongs to this budget file.
+
+    The template is user-supplied JSON that is later passed straight to
+    LedgerPosting.objects.create(account_id=..., category_id=...). Without this
+    check a user could point a posting at another tenant's account or category.
+    """
+    account_ids = {p.get("account_id") for p in postings if p.get("account_id") is not None}
+    category_ids = {p.get("category_id") for p in postings if p.get("category_id") is not None}
+
+    if account_ids:
+        owned = set(
+            Account.objects.filter(
+                budget_file=budget_file, id__in=account_ids
+            ).values_list("id", flat=True)
+        )
+        unknown = account_ids - owned
+        if unknown:
+            raise ValueError(f"Unknown account ids for this budget file: {sorted(unknown)}")
+
+    if category_ids:
+        owned = set(
+            CategoryV2.objects.filter(
+                budget_file=budget_file, id__in=category_ids
+            ).values_list("id", flat=True)
+        )
+        unknown = category_ids - owned
+        if unknown:
+            raise ValueError(f"Unknown category ids for this budget file: {sorted(unknown)}")
+
+
 def materialize_scheduled_transaction(schedule: ScheduledTransaction):
     template = schedule.transaction_template or {}
     postings = template.get("postings", [])
     if not postings or not _validate_postings_balance(postings):
         raise ValueError("Scheduled transaction template postings must be balanced")
+
+    _validate_template_posting_targets(schedule.budget_file, postings)
 
     with transaction.atomic():
         ledger_tx = LedgerTransaction.objects.create(

--- a/api/pft/finance_views.py
+++ b/api/pft/finance_views.py
@@ -4,27 +4,9 @@ from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from .models import (
-    Account,
-    BudgetFile,
-    BudgetMonth,
-    CategoryGroupV2,
-    CategoryV2,
-    EncryptedBackupBundle,
-    EnvelopeAssignment,
-    ExportJob,
-    ImportJob,
-    LedgerPosting,
-    LedgerTransaction,
-    Payee,
-    SavedReport,
-    ScheduledTransaction,
-    Tag,
-    TransactionEvent,
-    TransactionRule,
-)
 from .finance_serializers import (
     AccountSerializer,
     BudgetFileSerializer,
@@ -58,9 +40,46 @@ from .finance_services import (
     run_report,
     zero_budget_month,
 )
+from .models import (
+    Account,
+    BudgetFile,
+    BudgetMonth,
+    CategoryGroupV2,
+    CategoryV2,
+    EncryptedBackupBundle,
+    EnvelopeAssignment,
+    ExportJob,
+    ImportJob,
+    LedgerPosting,
+    LedgerTransaction,
+    Payee,
+    SavedReport,
+    ScheduledTransaction,
+    Tag,
+    TransactionEvent,
+    TransactionRule,
+)
+
+
+def parse_iso_date(raw, field_name):
+    """Parse a YYYY-MM-DD string, raising a 400 rather than a 500 on garbage."""
+    if raw in (None, ""):
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(
+            {field_name: "Expected a date in YYYY-MM-DD format."}
+        ) from exc
 
 
 class UserScopedModelViewSet(viewsets.ModelViewSet):
+    """Base class for the finance viewsets.
+
+    NOTE: this only enforces authentication. Every subclass is still responsible
+    for scoping its own get_queryset() to request.user.
+    """
+
     permission_classes = [permissions.IsAuthenticated]
 
 
@@ -93,8 +112,7 @@ class BudgetFileViewSet(UserScopedModelViewSet):
     @action(detail=True, methods=["get"], url_path="balances")
     def balances(self, request, pk=None):
         budget_file = self.get_object()
-        as_of = request.query_params.get("as_of")
-        as_of_date = date.fromisoformat(as_of) if as_of else None
+        as_of_date = parse_iso_date(request.query_params.get("as_of"), "as_of")
         return Response(
             {
                 "as_of": as_of_date.isoformat() if as_of_date else None,
@@ -201,6 +219,18 @@ class LedgerTransactionViewSet(UserScopedModelViewSet):
             id__in=ids,
             budget_file__user=request.user,
         )
+
+        # `payee` is a raw id from the request body. Without this check a user
+        # could attach another tenant's payee to their own transactions.
+        if patch.get("payee") is not None:
+            owned_payee = Payee.objects.filter(
+                pk=patch["payee"], budget_file__user=request.user
+            ).exists()
+            if not owned_payee:
+                return Response(
+                    {"detail": "Unknown payee."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
         updated_count = queryset.update(**patch, updated_at=timezone.now())
 
         budget_file_ids = queryset.values_list("budget_file_id", flat=True).distinct()
@@ -312,13 +342,20 @@ class ScheduledTransactionViewSet(UserScopedModelViewSet):
 
     @action(detail=False, methods=["post"], url_path="run-due")
     def run_due(self, request):
-        run_date_raw = request.data.get("run_date")
-        run_date = date.fromisoformat(run_date_raw) if run_date_raw else timezone.now().date()
+        run_date = (
+            parse_iso_date(request.data.get("run_date"), "run_date")
+            or timezone.now().date()
+        )
         due_items = self.get_queryset().filter(is_active=True, next_run_date__lte=run_date)
 
         created_ids = []
         for schedule in due_items:
-            ledger_tx = materialize_scheduled_transaction(schedule)
+            try:
+                ledger_tx = materialize_scheduled_transaction(schedule)
+            except ValueError as exc:
+                raise ValidationError(
+                    {"detail": f"Scheduled transaction {schedule.id}: {exc}"}
+                ) from exc
             created_ids.append(ledger_tx.id)
 
         return Response({"created_transaction_ids": created_ids})
@@ -389,7 +426,10 @@ class ReportViewSet(UserScopedModelViewSet):
         if not budget_file:
             return Response({"detail": "Budget file not found"}, status=404)
 
-        result = run_report(budget_file, request.data)
+        try:
+            result = run_report(budget_file, request.data)
+        except ValueError as exc:
+            raise ValidationError({"detail": str(exc)}) from exc
         return Response(result)
 
     @action(detail=True, methods=["post"], url_path="run")
@@ -397,7 +437,10 @@ class ReportViewSet(UserScopedModelViewSet):
         saved_report = self.get_object()
         payload = dict(saved_report.definition or {})
         payload["report_type"] = saved_report.report_type
-        result = run_report(saved_report.budget_file, payload)
+        try:
+            result = run_report(saved_report.budget_file, payload)
+        except ValueError as exc:
+            raise ValidationError({"detail": str(exc)}) from exc
         return Response(result)
 
 

--- a/api/pft/management/commands/prune_finance_jobs.py
+++ b/api/pft/management/commands/prune_finance_jobs.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from pft.models import ExportJob, ImportJob
+
+
+class Command(BaseCommand):
+    help = (
+        "Clear stored payloads from finished import/export jobs older than the "
+        "retention window. These fields hold plaintext financial data."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=settings.FINTRACK_JOB_RETENTION_DAYS,
+            help="Retention window in days (default: FINTRACK_JOB_RETENTION_DAYS).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be cleared without writing.",
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        dry_run = options["dry_run"]
+        cutoff = timezone.now() - timezone.timedelta(days=days)
+
+        stale_imports = ImportJob.objects.filter(
+            created_at__lt=cutoff
+        ).exclude(source_payload="")
+        stale_exports = ExportJob.objects.filter(created_at__lt=cutoff).exclude(
+            content_text="", content_b64=""
+        )
+
+        import_count = stale_imports.count()
+        export_count = stale_exports.count()
+
+        if dry_run:
+            self.stdout.write(
+                f"Would clear {import_count} import payload(s) and "
+                f"{export_count} export payload(s) older than {days} days."
+            )
+            return
+
+        stale_imports.update(source_payload="")
+        stale_exports.update(content_text="", content_b64="")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Cleared {import_count} import payload(s) and "
+                f"{export_count} export payload(s) older than {days} days."
+            )
+        )

--- a/api/pft/models.py
+++ b/api/pft/models.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models import Q, Sum
 
 
-
 class CustomUserManager(BaseUserManager):
     def create_user(self, email, password=None, **extra_fields):
         if not email:

--- a/api/pft/routers.py
+++ b/api/pft/routers.py
@@ -1,6 +1,9 @@
 from rest_framework.routers import DefaultRouter
+
 from .views import (
-    CategoryViewSet,TransactionViewSet, BudgetViewSet,
+    BudgetViewSet,
+    CategoryViewSet,
+    TransactionViewSet,
 )
 
 router = DefaultRouter()

--- a/api/pft/serializers.py
+++ b/api/pft/serializers.py
@@ -1,8 +1,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
-from .models import (
-    Transaction, Category, Budget
-)
+
+from .models import Budget, Category, Transaction
 
 User = get_user_model()
 
@@ -67,8 +66,12 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
 class CategorySerializer(serializers.ModelSerializer):
     def validate_name(self, value):
         user = self.context["request"].user
-        # Check if category with same name exists for this user
-        if Category.objects.filter(user=user, name=value).exists():
+        # A category name must be unique per user. Exclude the instance being
+        # updated, otherwise every PATCH that keeps the same name is rejected.
+        queryset = Category.objects.filter(user=user, name=value)
+        if self.instance is not None:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        if queryset.exists():
             raise serializers.ValidationError(
                 "A category with this name already exists."
             )
@@ -87,10 +90,22 @@ class TransactionSerializer(serializers.ModelSerializer):
         model = Transaction
         fields = ['id', 'user', 'title', 'amount', 'type', 'category',
                  'transaction_date', 'created_at', 'updated_at']
-        read_only_fields = ['created_at', 'updated_at']
+        # `user` is owned by the view (perform_create/perform_update), never by
+        # the client. Leaving it writable let one user reassign a transaction to
+        # another account, and made `user` a required field on create.
+        read_only_fields = ['user', 'created_at', 'updated_at']
         extra_kwargs = {
             "category": {"required": False, "allow_null": True},
         }
+
+    def validate_category(self, value):
+        """Reject categories that belong to somebody else."""
+        if value is None:
+            return value
+        user = self.context["request"].user
+        if value.user_id is not None and value.user_id != user.id:
+            raise serializers.ValidationError("Unknown category.")
+        return value
 
     def to_representation(self, instance):
         # Ensure amount is always serialized as Decimal
@@ -99,7 +114,6 @@ class TransactionSerializer(serializers.ModelSerializer):
         return ret
 
     def create(self, validated_data):
-        # Handle the amount encryption during creation
         amount = validated_data.pop('amount', None)
         transaction = Transaction(**validated_data)
         if amount is not None:
@@ -108,7 +122,6 @@ class TransactionSerializer(serializers.ModelSerializer):
         return transaction
 
     def update(self, instance, validated_data):
-        # Handle the amount encryption during update
         amount = validated_data.pop('amount', None)
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
@@ -118,6 +131,15 @@ class TransactionSerializer(serializers.ModelSerializer):
         return instance
 
 class BudgetSerializer(serializers.ModelSerializer):
+    def validate_category(self, value):
+        """Reject categories that belong to somebody else."""
+        if value is None:
+            return value
+        user = self.context["request"].user
+        if value.user_id is not None and value.user_id != user.id:
+            raise serializers.ValidationError("Unknown category.")
+        return value
+
     def validate(self, data):
         user = self.context["request"].user
         # Check if budget already exists for this user, category, month, and year
@@ -145,4 +167,5 @@ class BudgetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Budget
         fields = "__all__"
+        # Set by the view, never by the client.
         read_only_fields = ["user"]

--- a/api/pft/signals.py
+++ b/api/pft/signals.py
@@ -1,6 +1,7 @@
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.contrib.auth import get_user_model
+
 from .models import Account, BudgetFile, Category, CategoryGroupV2, CategoryV2
 
 User = get_user_model()

--- a/api/pft/tests/test_api_finance_v1.py
+++ b/api/pft/tests/test_api_finance_v1.py
@@ -5,8 +5,14 @@ from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from pft.models import Account, BudgetFile, CategoryV2, ImportJob, LedgerPosting, LedgerTransaction
-
+from pft.models import (
+    Account,
+    BudgetFile,
+    CategoryV2,
+    ImportJob,
+    LedgerPosting,
+    LedgerTransaction,
+)
 
 User = get_user_model()
 

--- a/api/pft/tests/test_api_smoke.py
+++ b/api/pft/tests/test_api_smoke.py
@@ -7,7 +7,6 @@ from rest_framework.test import APITestCase
 
 from pft.models import Category, Transaction
 
-
 User = get_user_model()
 
 

--- a/api/pft/tests/test_auth_hardening.py
+++ b/api/pft/tests/test_auth_hardening.py
@@ -1,0 +1,157 @@
+"""Tests for logout, token revocation and throttling.
+
+Before this, a refresh token could not be revoked at all: there was no logout
+endpoint and a password change left every outstanding token working.
+"""
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.throttling import SimpleRateThrottle
+
+User = get_user_model()
+
+PASSWORD = "StrongPass123!"
+
+
+class TokenRevocationTests(APITestCase):
+    def setUp(self):
+        self.email = "revoke@example.com"
+        self.user = User.objects.create_user(
+            email=self.email, username=self.email, password=PASSWORD
+        )
+        cache.clear()
+
+    def obtain_tokens(self):
+        response = self.client.post(
+            "/api/token/",
+            {"email": self.email, "password": PASSWORD},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.data["access"], response.data["refresh"]
+
+    def test_refresh_works_before_logout(self):
+        _, refresh = self.obtain_tokens()
+        response = self.client.post("/api/token/refresh/", {"refresh": refresh}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_logout_revokes_the_refresh_token(self):
+        access, refresh = self.obtain_tokens()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+
+        logout = self.client.post("/api/token/logout/", {"refresh": refresh}, format="json")
+        self.assertEqual(logout.status_code, status.HTTP_200_OK)
+
+        response = self.client.post("/api/token/refresh/", {"refresh": refresh}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_logout_all_revokes_every_session(self):
+        _, refresh_one = self.obtain_tokens()
+        access_two, refresh_two = self.obtain_tokens()
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_two}")
+        logout = self.client.post("/api/token/logout/", {"all": True}, format="json")
+        self.assertEqual(logout.status_code, status.HTTP_200_OK)
+
+        for token in (refresh_one, refresh_two):
+            response = self.client.post(
+                "/api/token/refresh/", {"refresh": token}, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_logout_requires_authentication(self):
+        response = self.client.post("/api/token/logout/", {"all": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_logout_without_a_token_is_a_400(self):
+        access, _ = self.obtain_tokens()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+        response = self.client.post("/api/token/logout/", {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_changing_the_password_revokes_outstanding_tokens(self):
+        access, refresh = self.obtain_tokens()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+
+        response = self.client.post(
+            "/api/v1/profile/change-password/",
+            {
+                "current_password": PASSWORD,
+                "new_password": "EvenStronger456!",
+                "confirm_password": "EvenStronger456!",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        refreshed = self.client.post(
+            "/api/token/refresh/", {"refresh": refresh}, format="json"
+        )
+        self.assertEqual(
+            refreshed.status_code,
+            status.HTTP_401_UNAUTHORIZED,
+            msg="a password change must not leave old refresh tokens working",
+        )
+
+
+class ThrottleTests(APITestCase):
+    """Rate limits on the endpoints worth guessing against.
+
+    Note: SimpleRateThrottle.THROTTLE_RATES is bound at import time, so
+    override_settings(REST_FRAMEWORK=...) does not reach it. Patch the bound
+    dict instead.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.rates = mock.patch.dict(
+            SimpleRateThrottle.THROTTLE_RATES,
+            {"register": "2/hour", "login": "2/min", "password_change": "2/min"},
+        )
+        self.rates.start()
+        self.addCleanup(self.rates.stop)
+        self.addCleanup(cache.clear)
+
+    def test_registration_is_throttled(self):
+        statuses = [
+            self.client.post(
+                "/api/v1/register/",
+                {
+                    "email": f"throttle{index}@example.com",
+                    "password": PASSWORD,
+                    "confirm_password": PASSWORD,
+                },
+                format="json",
+            ).status_code
+            for index in range(4)
+        ]
+
+        self.assertEqual(statuses[:2], [status.HTTP_201_CREATED] * 2)
+        self.assertIn(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            statuses,
+            msg=f"registration was never throttled: {statuses}",
+        )
+
+    def test_login_is_throttled(self):
+        User.objects.create_user(
+            email="login@example.com", username="login@example.com", password=PASSWORD
+        )
+        statuses = [
+            self.client.post(
+                "/api/token/",
+                {"email": "login@example.com", "password": "wrong-password"},
+                format="json",
+            ).status_code
+            for _ in range(4)
+        ]
+
+        self.assertIn(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            statuses,
+            msg=f"login was never throttled: {statuses}",
+        )

--- a/api/pft/tests/test_tenant_isolation.py
+++ b/api/pft/tests/test_tenant_isolation.py
@@ -1,0 +1,392 @@
+"""Cross-tenant isolation tests.
+
+Every other test module exercises a single user, so nothing verified that user B
+cannot reach user A's data. For a self-hosted, multi-user finance app that is the
+guarantee that matters most, so it gets its own suite.
+
+Each test is written so that a regression produces a failure naming the exact
+endpoint that leaked.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from pft.models import (
+    Account,
+    Budget,
+    BudgetFile,
+    Category,
+    CategoryV2,
+    LedgerPosting,
+    LedgerTransaction,
+    Payee,
+    ScheduledTransaction,
+    Transaction,
+)
+
+User = get_user_model()
+
+
+class TenantFixture:
+    """A user plus the finance objects auto-created for them on signup."""
+
+    def __init__(self, email):
+        self.user = User.objects.create_user(
+            email=email, username=email, password="StrongPass123!"
+        )
+        self.budget_file = BudgetFile.objects.get(user=self.user, is_default=True)
+        self.account = Account.objects.get(budget_file=self.budget_file, name="Cash")
+        self.category_v2 = CategoryV2.objects.filter(
+            budget_file=self.budget_file, kind=CategoryV2.KIND_EXPENSE
+        ).first()
+        self.category = Category.objects.create(
+            user=self.user, name=f"Private {email}", type="expense"
+        )
+        self.transaction = Transaction.objects.create(
+            user=self.user,
+            title=f"Private transaction for {email}",
+            amount="42.00",
+            type="expense",
+            category=self.category,
+            transaction_date=date(2026, 3, 10),
+        )
+        self.budget = Budget.objects.create(
+            user=self.user,
+            category=self.category,
+            month=3,
+            year=2026,
+            amount_limit="500.00",
+        )
+        self.payee = Payee.objects.create(
+            budget_file=self.budget_file, name=f"Payee {email}"
+        )
+
+
+class TenantIsolationTestCase(APITestCase):
+    def setUp(self):
+        self.alice = TenantFixture("alice@example.com")
+        self.bob = TenantFixture("bob@example.com")
+        self.client.force_authenticate(user=self.bob.user)
+
+    def as_alice(self):
+        self.client.force_authenticate(user=self.alice.user)
+
+    def as_bob(self):
+        self.client.force_authenticate(user=self.bob.user)
+
+
+class LegacyApiIsolationTests(TenantIsolationTestCase):
+    """/api/v1/* - the transaction/category/budget endpoints."""
+
+    def test_transaction_list_excludes_other_users(self):
+        response = self.client.get("/api/v1/transactions/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {row["id"] for row in response.data["results"]}
+        self.assertNotIn(self.alice.transaction.id, returned_ids)
+        self.assertIn(self.bob.transaction.id, returned_ids)
+
+    def test_cannot_retrieve_other_users_transaction(self):
+        response = self.client.get(f"/api/v1/transactions/{self.alice.transaction.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cannot_update_other_users_transaction(self):
+        response = self.client.patch(
+            f"/api/v1/transactions/{self.alice.transaction.id}/",
+            {"title": "hijacked"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.alice.transaction.refresh_from_db()
+        self.assertNotEqual(self.alice.transaction.title, "hijacked")
+
+    def test_cannot_delete_other_users_transaction(self):
+        response = self.client.delete(f"/api/v1/transactions/{self.alice.transaction.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(Transaction.objects.filter(id=self.alice.transaction.id).exists())
+
+    def test_cannot_reassign_own_transaction_to_another_user(self):
+        """Regression: `user` used to be writable, so a PUT could donate a row."""
+        response = self.client.put(
+            f"/api/v1/transactions/{self.bob.transaction.id}/",
+            {
+                "user": self.alice.user.id,
+                "title": "still mine",
+                "amount": "42.00",
+                "type": "expense",
+                "transaction_date": "2026-03-10",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.bob.transaction.refresh_from_db()
+        self.assertEqual(self.bob.transaction.user_id, self.bob.user.id)
+
+    def test_create_transaction_does_not_require_user_field(self):
+        response = self.client.post(
+            "/api/v1/transactions/",
+            {
+                "title": "Coffee",
+                "amount": "12.34",
+                "type": "expense",
+                "transaction_date": "2026-03-10",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            Transaction.objects.get(id=response.data["id"]).user_id, self.bob.user.id
+        )
+
+    def test_cannot_attach_another_users_category_to_a_transaction(self):
+        response = self.client.post(
+            "/api/v1/transactions/",
+            {
+                "title": "Sneaky",
+                "amount": "1.00",
+                "type": "expense",
+                "category": self.alice.category.id,
+                "transaction_date": "2026-03-10",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_retrieve_other_users_category(self):
+        response = self.client.get(f"/api/v1/categories/{self.alice.category.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cannot_delete_other_users_category(self):
+        response = self.client.delete(f"/api/v1/categories/{self.alice.category.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(Category.objects.filter(id=self.alice.category.id).exists())
+
+    def test_global_categories_are_readable_but_not_writable(self):
+        """Regression: global (user IS NULL) rows were editable by everyone."""
+        shared = Category.objects.create(user=None, name="Shared Global", type="expense")
+
+        listed = self.client.get("/api/v1/categories/")
+        self.assertIn(shared.id, {row["id"] for row in listed.data["results"]})
+
+        for method, kwargs in (
+            ("patch", {"data": {"name": "hijacked"}, "format": "json"}),
+            ("delete", {}),
+        ):
+            response = getattr(self.client, method)(
+                f"/api/v1/categories/{shared.id}/", **kwargs
+            )
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_404_NOT_FOUND,
+                msg=f"{method.upper()} on a global category should not be allowed",
+            )
+
+        shared.refresh_from_db()
+        self.assertEqual(shared.name, "Shared Global")
+
+    def test_renaming_a_category_to_its_own_name_is_allowed(self):
+        """Regression: the uniqueness check did not exclude the instance."""
+        response = self.client.patch(
+            f"/api/v1/categories/{self.bob.category.id}/",
+            {"name": self.bob.category.name},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cannot_retrieve_other_users_budget(self):
+        response = self.client.get(f"/api/v1/budgets/{self.alice.budget.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cannot_budget_against_another_users_category(self):
+        response = self.client.post(
+            "/api/v1/budgets/",
+            {
+                "category": self.alice.category.id,
+                "month": 4,
+                "year": 2026,
+                "amount_limit": "100.00",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class FinanceApiIsolationTests(TenantIsolationTestCase):
+    """/api/v1/finance/* - the double-entry ledger endpoints."""
+
+    def other_tenant_detail_urls(self):
+        alice = self.alice
+        return {
+            "budget-files": f"/api/v1/finance/budget-files/{alice.budget_file.id}/",
+            "accounts": f"/api/v1/finance/accounts/{alice.account.id}/",
+            "categories": f"/api/v1/finance/categories/{alice.category_v2.id}/",
+            "payees": f"/api/v1/finance/payees/{alice.payee.id}/",
+        }
+
+    def test_detail_endpoints_hide_other_tenants(self):
+        for name, url in self.other_tenant_detail_urls().items():
+            with self.subTest(resource=name):
+                self.assertEqual(
+                    self.client.get(url).status_code,
+                    status.HTTP_404_NOT_FOUND,
+                )
+                self.assertEqual(
+                    self.client.delete(url).status_code,
+                    status.HTTP_404_NOT_FOUND,
+                )
+
+    def test_list_endpoints_only_return_own_rows(self):
+        cases = {
+            "budget-files": (self.bob.budget_file.id, self.alice.budget_file.id),
+            "accounts": (self.bob.account.id, self.alice.account.id),
+            "payees": (self.bob.payee.id, self.alice.payee.id),
+        }
+        for resource, (mine, theirs) in cases.items():
+            with self.subTest(resource=resource):
+                response = self.client.get(f"/api/v1/finance/{resource}/")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                returned = {row["id"] for row in response.data}
+                self.assertIn(mine, returned)
+                self.assertNotIn(theirs, returned)
+
+    def test_cannot_create_a_transaction_in_another_tenants_budget_file(self):
+        payload = {
+            "budget_file": self.alice.budget_file.id,
+            "transaction_date": "2026-03-10",
+            "memo": "Trespassing",
+            "postings": [
+                {"account": self.alice.account.id, "amount": "-5.00", "sort_order": 0},
+                {"category": self.alice.category_v2.id, "amount": "5.00", "sort_order": 1},
+            ],
+        }
+        response = self.client.post("/api/v1/finance/transactions/", payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            LedgerTransaction.objects.filter(budget_file=self.alice.budget_file).exists()
+        )
+
+    def test_bulk_update_cannot_attach_another_tenants_payee(self):
+        """Regression: `payee` was applied as a raw id with no ownership check."""
+        ledger_tx = LedgerTransaction.objects.create(
+            budget_file=self.bob.budget_file,
+            transaction_date=date(2026, 3, 10),
+            memo="mine",
+        )
+        response = self.client.post(
+            "/api/v1/finance/transactions/bulk-update/",
+            {"ids": [ledger_tx.id], "updates": {"payee": self.alice.payee.id}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        ledger_tx.refresh_from_db()
+        self.assertIsNone(ledger_tx.payee_id)
+
+    def test_scheduled_transaction_cannot_post_to_another_tenants_account(self):
+        """Regression: template account_id/category_id were trusted verbatim."""
+        schedule = ScheduledTransaction.objects.create(
+            budget_file=self.bob.budget_file,
+            name="Rent",
+            is_active=True,
+            start_date=date(2026, 3, 1),
+            next_run_date=date(2026, 3, 1),
+            frequency=ScheduledTransaction.FREQ_MONTHLY,
+            interval=1,
+            transaction_template={
+                "memo": "Rent",
+                "postings": [
+                    {"account_id": self.alice.account.id, "amount": "-100.00"},
+                    {"category_id": self.bob.category_v2.id, "amount": "100.00"},
+                ],
+            },
+        )
+
+        response = self.client.post(
+            "/api/v1/finance/scheduled-transactions/run-due/",
+            {"run_date": "2026-03-02"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            LedgerPosting.objects.filter(account=self.alice.account).exists(),
+            msg="a schedule wrote a posting into another tenant's account",
+        )
+        schedule.refresh_from_db()
+        self.assertIsNone(schedule.last_run_at)
+
+    def test_report_run_rejects_another_tenants_budget_file(self):
+        response = self.client.post(
+            "/api/v1/finance/reports/run/",
+            {"budget_file": self.alice.budget_file.id, "report_type": "net_worth"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class MalformedInputTests(TenantIsolationTestCase):
+    """Bad input should be a 400, never a 500."""
+
+    def test_balances_rejects_a_malformed_date(self):
+        response = self.client.get(
+            f"/api/v1/finance/budget-files/{self.bob.budget_file.id}/balances/?as_of=not-a-date"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_report_rejects_a_malformed_date(self):
+        response = self.client.post(
+            "/api/v1/finance/reports/run/",
+            {
+                "budget_file": self.bob.budget_file.id,
+                "report_type": "cash_flow",
+                "start_date": "13/13/2026",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_run_due_rejects_a_malformed_date(self):
+        response = self.client.post(
+            "/api/v1/finance/scheduled-transactions/run-due/",
+            {"run_date": "yesterday"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class UnauthenticatedAccessTests(APITestCase):
+    """Nothing but registration, tokens, docs and health is public."""
+
+    PROTECTED_URLS = [
+        "/api/v1/me/",
+        "/api/v1/transactions/",
+        "/api/v1/categories/",
+        "/api/v1/budgets/",
+        "/api/v1/finance/budget-files/",
+        "/api/v1/finance/accounts/",
+        "/api/v1/finance/categories/",
+        "/api/v1/finance/transactions/",
+        "/api/v1/finance/postings/",
+        "/api/v1/finance/payees/",
+        "/api/v1/finance/tags/",
+        "/api/v1/finance/budget-months/",
+        "/api/v1/finance/envelope-assignments/",
+        "/api/v1/finance/scheduled-transactions/",
+        "/api/v1/finance/rules/",
+        "/api/v1/finance/reports/",
+        "/api/v1/finance/exports/",
+        "/api/v1/finance/backups/",
+        "/api/v1/finance/imports/",
+    ]
+
+    def test_protected_endpoints_require_authentication(self):
+        for url in self.PROTECTED_URLS:
+            with self.subTest(url=url):
+                self.assertEqual(
+                    self.client.get(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED,
+                )
+
+    def test_healthz_is_public(self):
+        self.assertEqual(self.client.get("/healthz/").status_code, status.HTTP_200_OK)

--- a/api/pft/urls.py
+++ b/api/pft/urls.py
@@ -1,10 +1,11 @@
-from django.urls import path, include
+from django.urls import include, path
+
 from .routers import router
 from .views import (
-    RegisterUserAPIView,
-    MeView,
-    UpdateProfileView,
     ChangePasswordView,
+    MeView,
+    RegisterUserAPIView,
+    UpdateProfileView,
 )
 
 app_name = "pft"

--- a/api/pft/views.py
+++ b/api/pft/views.py
@@ -1,25 +1,89 @@
-from rest_framework import generics, permissions, viewsets, status, filters
+from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from rest_framework import filters, generics, permissions, status, viewsets
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
-from .models import (
-    Budget, Category, Transaction,
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.token_blacklist.models import (
+    BlacklistedToken,
+    OutstandingToken,
 )
-from django.core.validators import validate_email
-from django.core.exceptions import ValidationError
-from django.contrib.auth import get_user_model
-from django.contrib.auth.password_validation import validate_password
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+from .models import (
+    Budget,
+    Category,
+    Transaction,
+)
 from .serializers import (
     BudgetSerializer,
     CategorySerializer,
     TransactionSerializer,
-    UserRegistrationSerializer,
     UserProfileSerializer,
+    UserRegistrationSerializer,
 )
+
 
 class CustomPagination(PageNumberPagination):
     page_size = 100
+
+
+def blacklist_all_refresh_tokens(user):
+    """Revoke every outstanding refresh token for a user.
+
+    Used on logout-everywhere and after a password change, so a stolen refresh
+    token stops working the moment the owner reacts.
+    """
+    revoked = 0
+    for outstanding in OutstandingToken.objects.filter(user=user):
+        _, created = BlacklistedToken.objects.get_or_create(token=outstanding)
+        if created:
+            revoked += 1
+    return revoked
+
+
+class ThrottledTokenObtainPairView(TokenObtainPairView):
+    """Login, rate limited per IP so the password field cannot be brute forced."""
+
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "login"
+
+
+class LogoutView(APIView):
+    """Revoke a refresh token.
+
+    POST {"refresh": "<token>"} revokes that token. POST {"all": true} revokes
+    every session for the current user.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        if request.data.get("all"):
+            revoked = blacklist_all_refresh_tokens(request.user)
+            return Response({"detail": "All sessions signed out.", "revoked": revoked})
+
+        refresh_token = request.data.get("refresh")
+        if not refresh_token:
+            return Response(
+                {"detail": "refresh is required (or pass all=true)."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            RefreshToken(refresh_token).blacklist()
+        except TokenError:
+            # An already-revoked or malformed token means the caller is signed
+            # out either way; do not leak which case it was.
+            pass
+
+        return Response({"detail": "Signed out."})
 
 
 # CATEGORY VIEWSET
@@ -29,12 +93,20 @@ class CategoryViewSet(viewsets.ModelViewSet):
     pagination_class = CustomPagination
 
     def get_queryset(self):
-        return (
-            Category.objects.filter(user=self.request.user)
-            | Category.objects.filter(user__isnull=True)
-        ).order_by("name", "id")
+        owned = Category.objects.filter(user=self.request.user)
+
+        # Global categories (user IS NULL) are shared by every account, so they
+        # are readable by all but writable by none: including them in the
+        # write queryset let any user edit or delete them for everybody.
+        if self.request.method not in permissions.SAFE_METHODS:
+            return owned.order_by("name", "id")
+
+        return (owned | Category.objects.filter(user__isnull=True)).order_by("name", "id")
 
     def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
         serializer.save(user=self.request.user)
 
 
@@ -67,6 +139,9 @@ class TransactionViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
+    def perform_update(self, serializer):
+        serializer.save(user=self.request.user)
+
 
 # BUDGET VIEWSET
 class BudgetViewSet(viewsets.ModelViewSet):
@@ -78,6 +153,9 @@ class BudgetViewSet(viewsets.ModelViewSet):
         return Budget.objects.filter(user=self.request.user).order_by("-year", "-month", "id")
 
     def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
         serializer.save(user=self.request.user)
 
     def create(self, request, *args, **kwargs):
@@ -98,6 +176,8 @@ class BudgetViewSet(viewsets.ModelViewSet):
 class RegisterUserAPIView(generics.CreateAPIView):
     serializer_class = UserRegistrationSerializer
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "register"
 
     def create(self, request, *args, **kwargs):
         # Get email from request data
@@ -156,6 +236,8 @@ class UpdateProfileView(generics.UpdateAPIView):
 
 class ChangePasswordView(APIView):
     permission_classes = [IsAuthenticated]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "password_change"
 
     def post(self, request):
         user = request.user
@@ -188,6 +270,15 @@ class ChangePasswordView(APIView):
 
         user.set_password(new_password)
         user.save()
+
+        # Changing a password must end every other session, otherwise a stolen
+        # refresh token survives the exact event meant to stop it.
+        blacklist_all_refresh_tokens(user)
+
         return Response(
-            {"message": "Password updated successfully"}, status=status.HTTP_200_OK
+            {
+                "message": "Password updated successfully",
+                "detail": "All existing sessions have been signed out.",
+            },
+            status=status.HTTP_200_OK,
         )

--- a/web/app/client/httpPFTClient.ts
+++ b/web/app/client/httpPFTClient.ts
@@ -22,9 +22,13 @@ interface OfflineQueuedRequest {
   created_at: string
 }
 
+// Reports, exports and imports are computed synchronously on the server, so a
+// 5s ceiling failed them client-side before the server had finished.
+const DEFAULT_TIMEOUT_MS = 30000
+
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: PFT_BASE_URL,
-  timeout: 5000,
+  timeout: DEFAULT_TIMEOUT_MS,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/web/app/lib/auth.ts
+++ b/web/app/lib/auth.ts
@@ -8,9 +8,15 @@ let authToken: string | null = null
 let isRefreshing = false
 let refreshSubscribers: ((token: string) => void)[] = []
 
+// `Secure` is only set when the page is served over HTTPS, otherwise the cookie
+// would be silently dropped on a plain-HTTP LAN install. `SameSite=Strict`
+// keeps the token off cross-site requests.
+const isSecureContext = typeof window !== 'undefined' && window.location.protocol === 'https:'
+const COOKIE_FLAGS = `path=/; SameSite=Strict${isSecureContext ? '; Secure' : ''}`
+
 function setCookie(name: string, value: string, days = 7) {
   const expires = new Date(Date.now() + days * 864e5).toUTCString()
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; ${COOKIE_FLAGS}`
 }
 
 function getCookie(name: string): string | null {
@@ -23,7 +29,7 @@ function getCookie(name: string): string | null {
 }
 
 function removeCookie(name: string) {
-  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ${COOKIE_FLAGS}`
 }
 
 export function setTokens(access: string, refresh: string) {
@@ -124,6 +130,26 @@ export async function refreshAccessToken() {
 }
 
 export async function logout() {
+  const accessToken = getAccessToken()
+  const refreshToken = getRefreshToken()
+
+  // Tell the server to blacklist the refresh token. Clearing the cookie alone
+  // only forgets it locally - the token stays valid until it expires.
+  if (accessToken && refreshToken) {
+    try {
+      await fetch(`${PFT_BASE_URL}/api/token/logout/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ refresh: refreshToken }),
+      })
+    } catch {
+      // Signing out locally must succeed even if the server is unreachable.
+    }
+  }
+
   removeTokens()
   authToken = null
   window.location.href = '/login'

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -2,10 +2,43 @@ server {
     listen 80;
     server_name localhost;
 
+    # Security headers. The app holds financial data and stores its tokens in
+    # JavaScript-readable cookies, so limiting the blast radius of an injected
+    # script matters.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    # No external hosts are needed: fonts are self-hosted and analytics is
+    # opt-in. connect-src stays 'self' because the API is proxied under /api/.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
     location / {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
+    }
+
+    # Hashed build assets are immutable; index.html and the service worker are not.
+    location /assets/ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location = /sw.js {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache";
+    }
+
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache";
     }
 
     # Proxy API requests to the Django backend
@@ -15,5 +48,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Exports and imports can take a while; do not cut them off at 60s.
+        proxy_read_timeout 300s;
+        client_max_body_size 20m;
+    }
+
+    location = /healthz/ {
+        proxy_pass http://api:8000/healthz/;
+        proxy_set_header Host $host;
+        access_log off;
     }
 }


### PR DESCRIPTION
**PR 3 of a stack**, based on #8. CI lands in the next PR.

## Why

FinTrack is multi-user and its pitch is that your financial data is yours. Nothing in the test suite asserted that one account could not reach another's — all 17 existing tests used a single user. Four holes, all reproducible:

## Cross-tenant writes

**1. Transaction ownership was client-controlled.** `TransactionSerializer` listed `user` in `fields` but not in `read_only_fields`, and `TransactionViewSet` defined `perform_create` but **not `perform_update`**. So:

```http
PUT /api/v1/transactions/{id}/   {"user": <other_id>, ...}
```

reassigned your transaction into someone else's account.

The same bug made `user` a *required* field. I hit this live — the documented endpoint was unusable:

```json
{"user":["This field is required."]}
```

**2. Global categories were writable by everyone.** `CategoryViewSet.get_queryset` unioned the caller's rows with `user__isnull=True` rows for *every* action, so any authenticated user could edit or delete a category every other user sees. Globals are now read-only.

**3. Scheduled transactions could post into another tenant's account.** `materialize_scheduled_transaction` passed `account_id` / `category_id` straight from user-supplied `transaction_template` JSON into `LedgerPosting.objects.create`. Only `budget_file` was validated. Triggerable via `POST /finance/scheduled-transactions/run-due/`.

**4. `bulk-update` accepted `payee` as a raw id** with no ownership check.

Serializers now also reject another user's category, and the category uniqueness check excludes the instance being updated — previously every `PATCH` that kept the same name failed.

## Session revocation

There was no logout endpoint, no blacklist, and a password change left every outstanding token valid.

- `ROTATE_REFRESH_TOKENS` + `BLACKLIST_AFTER_ROTATION` + the `token_blacklist` app
- `POST /api/token/logout/` — revokes one refresh token, or every session with `{"all": true}`
- Password change revokes all outstanding refresh tokens
- The web client now calls the endpoint instead of only forgetting the cookie
- JWT cookies get `SameSite=Strict`, and `Secure` when served over HTTPS

## Rate limiting

Nothing was throttled — login and registration were open to brute force and mass account creation. Global anon/user limits plus scoped limits on login (10/min), registration (5/hour) and password change (5/min), all env-configurable.

> Note: the settings half of the throttling and JWT config landed in #7, since it lives in `settings/base.py`.

## Bounds and robustness

- Cap import payloads and backup bundles — both stored as unbounded text and processed synchronously inside the request
- `manage.py prune_finance_jobs` clears retained plaintext financial payloads
- Malformed dates on `balances`, `reports/run` and `run-due` returned **500**; now 400
- Raise the 5s axios timeout that failed report/export calls before the server finished
- nginx set **no security headers at all**; adds CSP, nosniff, frame-deny, referrer policy, gzip and asset caching

## Verification

32 new tests, 49 total, all passing. Critically, I checked the isolation tests actually **fail on the old behaviour** rather than merely passing on the new — reverting the transaction and category fixes produces exactly two failures:

```
FAIL: test_create_transaction_does_not_require_user_field
AssertionError: 400 != 201
FAIL: test_global_categories_are_readable_but_not_writable
AssertionError: 200 != 404 : PATCH on a global category should not be allowed
```

Restoring the fixes: `Ran 49 tests ... OK`, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)