### PR TITLE
feat(admin): register the finance models in Django admin

### DIFF
--- a/api/pft/admin.py
+++ b/api/pft/admin.py
@@ -1,9 +1,31 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
 from .models import (
-    Category, Transaction, Budget, User,
+    Account,
+    Budget,
+    BudgetFile,
+    BudgetMonth,
+    Category,
+    CategoryGroupV2,
+    CategoryV2,
+    EncryptedBackupBundle,
+    EnvelopeAssignment,
+    ExportJob,
+    ImportJob,
+    LedgerPosting,
+    LedgerTransaction,
+    Payee,
+    SavedReport,
+    ScheduledTransaction,
+    Tag,
+    Transaction,
+    TransactionEvent,
+    TransactionRule,
+    User,
 )
+
 
 class TransactionAdminForm(forms.ModelForm):
     amount = forms.DecimalField(max_digits=12, decimal_places=2)
@@ -57,6 +79,135 @@ class TransactionAdmin(admin.ModelAdmin):
 
 admin.site.register(Category)
 admin.site.register(Budget)
+
+
+# --- Finance (double-entry ledger) domain ------------------------------------
+# These 16 models had no admin at all, so a self-hoster could not inspect or
+# repair their own ledger without a Django shell.
+
+
+@admin.register(BudgetFile)
+class BudgetFileAdmin(admin.ModelAdmin):
+    list_display = ("name", "user", "currency_code", "is_default", "created_at")
+    list_filter = ("is_default", "currency_code")
+    search_fields = ("name", "user__email")
+
+
+@admin.register(Account)
+class AccountAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "type", "opening_balance", "is_archived")
+    list_filter = ("type", "is_archived")
+    search_fields = ("name", "budget_file__name", "budget_file__user__email")
+
+
+@admin.register(CategoryGroupV2)
+class CategoryGroupAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "sort_order")
+    search_fields = ("name",)
+
+
+@admin.register(CategoryV2)
+class CategoryV2Admin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "group", "kind", "is_archived")
+    list_filter = ("kind", "is_archived")
+    search_fields = ("name",)
+
+
+@admin.register(Payee)
+class PayeeAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file")
+    search_fields = ("name",)
+
+
+@admin.register(Tag)
+class TagAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file")
+    search_fields = ("name",)
+
+
+class LedgerPostingInline(admin.TabularInline):
+    model = LedgerPosting
+    extra = 0
+    fields = ("account", "category", "amount", "memo", "sort_order")
+
+
+@admin.register(LedgerTransaction)
+class LedgerTransactionAdmin(admin.ModelAdmin):
+    list_display = ("transaction_date", "payee", "memo", "budget_file", "cleared", "source_type")
+    list_filter = ("cleared", "imported", "source_type")
+    search_fields = ("memo", "payee__name", "match_key")
+    date_hierarchy = "transaction_date"
+    inlines = [LedgerPostingInline]
+
+
+@admin.register(LedgerPosting)
+class LedgerPostingAdmin(admin.ModelAdmin):
+    list_display = ("transaction", "account", "category", "amount", "sort_order")
+    search_fields = ("transaction__memo", "account__name", "category__name")
+
+
+@admin.register(BudgetMonth)
+class BudgetMonthAdmin(admin.ModelAdmin):
+    list_display = ("budget_file", "year", "month", "mode")
+    list_filter = ("year", "month", "mode")
+
+
+@admin.register(EnvelopeAssignment)
+class EnvelopeAssignmentAdmin(admin.ModelAdmin):
+    list_display = ("budget_month", "category", "assigned_amount", "carryover_amount", "goal_type")
+    list_filter = ("goal_type",)
+
+
+@admin.register(ScheduledTransaction)
+class ScheduledTransactionAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "frequency", "interval", "next_run_date", "is_active")
+    list_filter = ("frequency", "is_active")
+    search_fields = ("name",)
+
+
+@admin.register(TransactionRule)
+class TransactionRuleAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "priority", "is_active")
+    list_filter = ("is_active",)
+    search_fields = ("name",)
+
+
+@admin.register(TransactionEvent)
+class TransactionEventAdmin(admin.ModelAdmin):
+    list_display = ("created_at", "budget_file", "operation", "transaction")
+    list_filter = ("operation",)
+    readonly_fields = ("created_at",)
+
+
+@admin.register(SavedReport)
+class SavedReportAdmin(admin.ModelAdmin):
+    list_display = ("name", "budget_file", "report_type", "pinned")
+    list_filter = ("report_type", "pinned")
+    search_fields = ("name",)
+
+
+@admin.register(ExportJob)
+class ExportJobAdmin(admin.ModelAdmin):
+    list_display = ("created_at", "budget_file", "format", "status", "file_name")
+    list_filter = ("format", "status")
+    # These hold a plaintext copy of exported financial data.
+    exclude = ("content_text", "content_b64")
+
+
+@admin.register(ImportJob)
+class ImportJobAdmin(admin.ModelAdmin):
+    list_display = ("created_at", "budget_file", "format", "status", "source_filename")
+    list_filter = ("format", "status")
+    # source_payload is the raw uploaded bank statement; not shown by default.
+    exclude = ("source_payload",)
+
+
+@admin.register(EncryptedBackupBundle)
+class EncryptedBackupBundleAdmin(admin.ModelAdmin):
+    list_display = ("created_at", "budget_file", "bundle_id", "encryption_algorithm")
+    readonly_fields = ("bundle_id", "created_at")
+    exclude = ("ciphertext", "salt", "nonce")
+
 
 admin.site.site_header = "FinTrack Admin"
 admin.site.site_title = "FinTrack Admin Portal"


### PR DESCRIPTION
**PR 4 of a stack**, based on #9.

## Why

`pft/admin.py` registered only `User`, `Category`, `Transaction` and `Budget`. **None of the 16 models that make up the double-entry ledger had an admin at all** — accounts, postings, payees, envelope assignments, scheduled transactions, rules, reports, import/export jobs, backup bundles.

For a self-hosted app that matters: when something goes wrong with your own ledger, the admin is the repair tool. Without it the only option was `manage.py shell`.

## What changed

All 16 finance models registered with list displays, filters, search, and date hierarchy where useful. `LedgerTransaction` gets a `LedgerPosting` inline so a transaction can be read as a balanced whole rather than reconstructed from a separate list.

**Plaintext financial data is excluded from the admin forms** rather than rendered into a page:

- `ImportJob.source_payload` — the raw uploaded bank statement
- `ExportJob.content_text` / `content_b64` — full copies of past exports
- `EncryptedBackupBundle.ciphertext` / `salt` / `nonce`

## Verification

`ruff check` clean, all 49 tests pass, Django system checks clean under both dev and prod settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)