### PR TITLE
ci: add pipelines, contributor docs, and fix the audit script's false PASS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What does this change?
+
+<!-- One or two sentences. Link the issue it closes, if there is one. -->
+
+Closes #
+
+## Why?
+
+<!-- What problem does this solve for someone running FinTrack? -->
+
+## How was it verified?
+
+<!-- Delete what does not apply. -->
+
+- [ ] `cd api && uv run ruff check . && uv run manage.py test`
+- [ ] `cd web && pnpm run lint && pnpm run build`
+- [ ] `docker compose build && docker compose up -d` and the app works end to end
+- [ ] Tried it manually (say what you did)
+
+## Checklist
+
+- [ ] Backend changes to a queryset, serializer or permission come with a
+      cross-tenant test in `api/pft/tests/test_tenant_isolation.py`
+- [ ] No secrets, `.env` files, or generated clients committed
+- [ ] Docs updated if the setup steps or API surface changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,183 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api:
+    name: API (lint + tests)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: fintrack
+          POSTGRES_USER: fintrack
+          POSTGRES_PASSWORD: fintrack
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fintrack"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DJANGO_SETTINGS_MODULE: app.settings.dev
+      DJANGO_ENV: development
+      SECRET_KEY: ci-only-not-a-real-secret
+      DJANGO_ALLOWED_HOSTS: localhost 127.0.0.1
+      DATABASE_NAME: fintrack
+      DATABASE_USER: fintrack
+      DATABASE_PASSWORD: fintrack
+      DATABASE_HOST: localhost
+      DATABASE_PORT: 5432
+
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Check for missing migrations
+        run: uv run manage.py makemigrations --check --dry-run
+
+      - name: Run tests
+        run: uv run manage.py test
+
+  web:
+    name: Web (lint + typecheck + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck and build
+        run: pnpm run build
+
+  landing:
+    name: Landing (build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: landing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: landing/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build
+
+  stack:
+    name: Docker stack smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap env files
+        run: make bootstrap
+
+      # This is the job that would have caught the web image failing to build
+      # and the API booting with a placeholder secret.
+      - name: Build images
+        run: docker compose build
+
+      - name: Start the stack
+        run: docker compose up -d
+
+      - name: Wait for the API to become healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/healthz/ > /dev/null; then
+              echo "API healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "API never became healthy" >&2
+          docker compose logs
+          exit 1
+
+      - name: Web is served
+        run: curl -fsS -o /dev/null http://localhost:5173
+
+      - name: Register a user and create a transaction
+        run: |
+          set -euo pipefail
+          EMAIL="ci-$(date +%s)@example.com"
+          PASSWORD='Sup3rSecret!pass'
+          curl -fsS -X POST http://localhost:8000/api/v1/register/ \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"confirm_password\":\"$PASSWORD\"}" > /dev/null
+          TOKEN=$(curl -fsS -X POST http://localhost:8000/api/token/ \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["access"])')
+          curl -fsS -X POST http://localhost:8000/api/v1/transactions/ \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d '{"title":"CI coffee","amount":"12.34","type":"expense","transaction_date":"2026-01-01"}' > /dev/null
+          echo "End-to-end register -> token -> transaction OK"
+
+      - name: Assert no placeholder secret is in use
+        run: |
+          docker compose exec -T api python -c "
+          from django.conf import settings
+          assert settings.SECRET_KEY, 'SECRET_KEY is empty'
+          assert settings.SECRET_KEY != 'some-random-secret-key', 'shipping the old public key'
+          assert settings.DEBUG is False, 'DEBUG must be off in the default stack'
+          print('settings OK')
+          "
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The repo has no root package.json, so the version cannot be inferred.
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
 
       - uses: actions/setup-node@v4
         with:
@@ -101,6 +104,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Publish images
+
+# Publishes multi-architecture images to GHCR. The previously published
+# `:latest` tags were arm64-only and hand-pushed, so they could not run on the
+# x86_64 hosts most people self-host on.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - name: api
+            context: ./api
+          - name: web
+            context: ./web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/fintrack-${{ matrix.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# Install once with: uv run pre-commit install   (from api/, or `pre-commit install`)
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.10.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^api/
+      - id: ruff-format
+        files: ^api/
+
+  # A committed SECRET_KEY is how this project shipped a public signing key for
+  # months. This hook is the backstop.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.0
+    hooks:
+      - id: gitleaks

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers through
+[private vulnerability reporting](https://github.com/AshishKapoor/fintrack/security/advisories/new)
+or by opening an issue if the matter is not sensitive. All complaints will be
+reviewed and investigated promptly and fairly.
+
+Community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,123 @@
-## 🤝 Contributing
+# Contributing to FinTrack
 
-Contributions, issues, and feature requests are welcome!
-Feel free to fork and submit a pull request.
+Thanks for taking the time. This guide is meant to get you from a fresh clone to a
+merged pull request without guessing.
+
+## Ground rules
+
+- Issues and pull requests are both welcome. For anything larger than a bug fix,
+  open an issue first so we can agree on the approach before you write code.
+- Security problems go through [private reporting](SECURITY.md), never a public issue.
+- Be kind. See the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Repository layout
+
+```
+api/        Django + DRF backend (uv, Python 3.12+)
+web/        React 19 + Vite single-page app (pnpm)
+landing/    Next.js marketing site (pnpm) - independent of the app
+docs/       Feature audit artifacts
+scripts/    Repo tooling
+```
+
+The backend has two API surfaces that both exist today:
+
+- `/api/v1/*` - the original flat `Transaction`/`Category`/`Budget` model.
+- `/api/v1/finance/*` - a double-entry ledger with envelope budgeting, rules,
+  scheduled transactions, reports, imports, exports and backups.
+
+The web app reads through the legacy shapes but writes to the finance API, via the
+hand-maintained adapter in `web/app/client/pft/`. Consolidating these is the
+biggest open piece of work.
+
+## Getting set up
+
+The fastest path is Docker:
+
+```bash
+make bootstrap && make dev
+```
+
+That starts Postgres, the API with autoreload on http://localhost:8000, and the web
+app on http://localhost:5173.
+
+### Backend without Docker
+
+```bash
+cd api && cp .env.example .env && uv sync && uv run manage.py migrate && uv run manage.py runserver
+```
+
+`uv` is the only supported Python toolchain - `uv.lock` is authoritative. There is
+no Poetry setup any more.
+
+### Frontend without Docker
+
+```bash
+cd web && cp .env.example .env && pnpm install && pnpm dev
+```
+
+pnpm's version is pinned by the `packageManager` field; run `corepack enable` once
+and it will be used automatically.
+
+## Before you open a pull request
+
+Run what CI runs:
+
+```bash
+cd api && uv run ruff check . && uv run manage.py test
+```
+
+```bash
+cd web && pnpm run lint && pnpm run build
+```
+
+And, if you touched anything in the Docker or settings layer:
+
+```bash
+make bootstrap && docker compose build && docker compose up -d && curl -fsS http://localhost:8000/healthz/
+```
+
+Optionally install the git hooks so formatting and secret scanning run locally:
+
+```bash
+uv run pre-commit install
+```
+
+## Conventions
+
+- **Commits** follow [Conventional Commits](https://www.conventionalcommits.org/):
+  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
+- **Python** is formatted and linted by Ruff (`line-length = 88`). Run
+  `uv run ruff check --fix .`, but read the diff: Ruff will happily delete
+  side-effect imports that matter.
+- **TypeScript** follows the ESLint flat config in `web/eslint.config.js`. Avoid
+  `any`; if you truly need it, explain why in a comment.
+- Do not commit generated API clients into `web/app/client/gen/` - that directory
+  is orval's output and is ignored. The maintained client lives in
+  `web/app/client/pft/`.
+
+## Testing expectations
+
+- Backend changes need tests. `api/pft/tests/` has three suites: smoke, finance,
+  and tenant isolation.
+- **Anything that touches a queryset, serializer or permission must have a
+  cross-tenant test** in `api/pft/tests/test_tenant_isolation.py`. This is a
+  multi-user finance app; "user B cannot see or change user A's data" is the
+  guarantee we care about most.
+- The frontend has no test harness yet. Adding one (vitest plus a Playwright smoke
+  path) is a genuinely valuable contribution.
+
+## Good first issues
+
+Look for the `good first issue` label. If none are open and you want somewhere to
+start, these are all real and self-contained:
+
+- Remove the ~21 unused shadcn components from `web/app/components/ui/`.
+- Move transaction filtering and sorting server-side; today they run over the
+  current page only, so the result count is wrong.
+- Replace the hand-rolled currency formatting in
+  `web/app/components/ui/currency-display.tsx` with
+  `Intl.NumberFormat(locale, { style: 'currency' })`, including the chart tooltips.
+- Register the finance models in `api/pft/admin.py`.
+- Implement the account-deletion flow behind the disabled button in
+  `web/app/pages/settings/index.tsx`.

--- a/docs/feature-audit/parity-report.md
+++ b/docs/feature-audit/parity-report.md
@@ -1,6 +1,6 @@
 # API/UI Parity Report
 
-Generated on `2026-03-10` by `scripts/feature_audit.py`.
+Generated on `2026-08-12` by `scripts/feature_audit.py`.
 
 ## Matrix Validation
 
@@ -22,7 +22,9 @@ Matrix validation errors:
 
 ## Parity Findings
 
-No parity findings.
+| Severity | Finding | Detail | Evidence |
+|---|---|---|---|
+| P2 | Backend routes missing from OpenAPI schema | 31 active endpoints are not represented in schema. | `api/pft/routers.py`<br>`api/pft/urls.py`<br>`web/schema/pft.yaml` |
 
 
 ## Schema Endpoints Not in Active Backend
@@ -32,5 +34,35 @@ No parity findings.
 
 ## Active Backend Endpoints Missing From Schema
 
-- None
+- `/api/v1/finance/`
+- `/api/v1/finance/accounts/`
+- `/api/v1/finance/accounts/{id}/`
+- `/api/v1/finance/backups/`
+- `/api/v1/finance/backups/{id}/`
+- `/api/v1/finance/budget-files/`
+- `/api/v1/finance/budget-files/{id}/`
+- `/api/v1/finance/budget-months/`
+- `/api/v1/finance/budget-months/{id}/`
+- `/api/v1/finance/categories/`
+- `/api/v1/finance/categories/{id}/`
+- `/api/v1/finance/category-groups/`
+- `/api/v1/finance/category-groups/{id}/`
+- `/api/v1/finance/envelope-assignments/`
+- `/api/v1/finance/envelope-assignments/{id}/`
+- `/api/v1/finance/exports/`
+- `/api/v1/finance/exports/{id}/`
+- `/api/v1/finance/imports/`
+- `/api/v1/finance/imports/{id}/`
+- `/api/v1/finance/payees/`
+- `/api/v1/finance/payees/{id}/`
+- `/api/v1/finance/postings/`
+- `/api/v1/finance/postings/{id}/`
+- `/api/v1/finance/reports/`
+- `/api/v1/finance/reports/{id}/`
+- `/api/v1/finance/rules/`
+- `/api/v1/finance/rules/{id}/`
+- `/api/v1/finance/tags/`
+- `/api/v1/finance/tags/{id}/`
+- `/api/v1/finance/transactions/`
+- `/api/v1/finance/transactions/{id}/`
 

--- a/scripts/feature_audit.py
+++ b/scripts/feature_audit.py
@@ -17,12 +17,13 @@ MATRIX_PATH = ROOT / "docs/feature-audit/feature-matrix.json"
 REPORT_PATH = ROOT / "docs/feature-audit/parity-report.md"
 SCHEMA_PATH = ROOT / "web/schema/pft.yaml"
 ROUTERS_PATH = ROOT / "api/pft/routers.py"
+FINANCE_ROUTERS_PATH = ROOT / "api/pft/finance_routers.py"
 PFT_URLS_PATH = ROOT / "api/pft/urls.py"
 APP_URLS_PATH = ROOT / "api/app/urls.py"
 TRANSACTIONS_PAGE_PATH = ROOT / "web/app/pages/transactions/index.tsx"
 RECENT_TRANSACTIONS_PATH = ROOT / "web/app/components/recent-transactions.tsx"
 WEB_APP_PATH = ROOT / "web/app"
-GENERATED_CLIENT_PATH = ROOT / "web/app/client/gen/pft"
+GENERATED_CLIENT_PATH = ROOT / "web/app/client/pft"
 
 ROW_REQUIRED_FIELDS = {
     "feature_id",
@@ -153,6 +154,14 @@ def extract_backend_endpoints() -> set[str]:
     for resource in re.findall(r'router\.register\("([^"]+)"', routers):
         endpoints.add(f"/api/v1/{resource}/")
         endpoints.add(f"/api/v1/{resource}/{{id}}/")
+
+    # The finance domain mounts 16 more resources under /api/v1/finance/.
+    # Omitting this file was why the parity report reported PASS while the
+    # entire API the UI actually calls was undocumented.
+    finance_routers = FINANCE_ROUTERS_PATH.read_text(encoding="utf-8")
+    for resource in re.findall(r'router\.register\("([^"]+)"', finance_routers):
+        endpoints.add(f"/api/v1/finance/{resource}/")
+        endpoints.add(f"/api/v1/finance/{resource}/{{id}}/")
 
     pft_urls = PFT_URLS_PATH.read_text(encoding="utf-8")
     for match in re.finditer(r'path\("([^"]+)"', pft_urls):


### PR DESCRIPTION
**PR 6 of a stack**, based on #11. This is where checks start running — the earlier PRs in the stack have no CI to show because CI is added here, once the tree is green.

## Why

There was **no CI of any kind**. `.github/` held two issue templates and nothing else. The 17 backend tests that already existed ran on nobody's machine, and neither frontend was linted, type-checked or built on a PR. That is how the web image came to be unbuildable and stayed that way.

## `ci.yml`

| Job | What it runs |
|---|---|
| **api** | ruff, `makemigrations --check --dry-run`, full test suite against a real Postgres service |
| **web** | eslint, `tsc -b`, vite build |
| **landing** | `next build` |
| **stack** | `docker compose build` + `up`, waits for `/healthz/`, then registers a user, obtains a token and creates a transaction over HTTP |

The **stack** job is the one that would have caught the broken web image. It also asserts the running instance is not using the old public `SECRET_KEY` and that `DEBUG` is off — so the class of regression this stack fixes cannot come back silently.

## `release.yml`

Publishes **multi-architecture** images (`linux/amd64,linux/arm64`) to GHCR on tag. The previously published `:latest` tags were **arm64-only** and pushed by hand, so they could not run on the x86_64 hosts most people self-host on.

## Contributor on-ramp

`CONTRIBUTING.md` was four lines of boilerplate. It now covers setup for both toolchains, what CI checks, commit conventions, and the rule that anything touching a queryset, serializer or permission needs a cross-tenant test. It also explains the two coexisting API surfaces — without that, the backend is genuinely hard for an outsider to read — and lists self-contained first issues.

Adds `CODE_OF_CONDUCT.md`, a PR template, and a pre-commit config running ruff and **GitLeaks**. GitLeaks is the backstop for exactly the mistake that put a `SECRET_KEY` in this repository; `api/README.md` documented the hook, but no config ever existed.

## The audit script was reporting a false PASS

`scripts/feature_audit.py` parsed `pft/routers.py` and **never `pft/finance_routers.py`**, so all 16 finance resources were invisible to it. The generated report therefore claimed:

```
## Active Backend Endpoints Missing From Schema
- None
```

with `Gate status: PASS` — while the entire API the UI actually calls was undocumented. Anyone using these artifacts to judge readiness was being misled. It now sees them and reports 31 missing endpoints, which is the truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)