### PR TITLE
docs: add architecture and self-hosting guides, regenerate the OpenAPI schema

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# Architecture
+
+This document explains how FinTrack is put together and, more usefully, *why it
+looks the way it does*. The backend currently carries two overlapping data
+models, which is the single most confusing thing about the codebase. That is
+explained in full below.
+
+## The shape of the system
+
+```
+                  ┌──────────────┐
+   browser ──────▶│  nginx (web) │  serves the built SPA
+                  │              │  proxies /api/ ──▶ gunicorn (api)
+                  └──────────────┘                        │
+                                                          ▼
+                                                   ┌─────────────┐
+                                                   │ PostgreSQL  │
+                                                   └─────────────┘
+```
+
+- `web/` is a React 19 single-page app built by Vite and served as static files
+  by nginx, which also proxies `/api/` to the backend. There is no server-side
+  rendering and no Node process at runtime.
+- `api/` is Django + Django REST Framework behind gunicorn. Authentication is
+  JWT (SimpleJWT); there are no server-side sessions for the API.
+- `landing/` is a separate Next.js marketing site. It is **not** part of the
+  self-hosted stack and is not referenced by `docker-compose.yml`.
+
+## The two API surfaces
+
+This is the part worth reading before changing anything.
+
+### `/api/v1/*` — the original flat model
+
+Three models, each owned directly by a user:
+
+| Model | Meaning |
+|---|---|
+| `Category` | a name plus `income`/`expense`. `user` may be NULL, meaning a global category shared by everyone (readable by all, writable by none). |
+| `Transaction` | a single signed amount with a title, type and date. |
+| `Budget` | a spending limit for one category in one month/year. |
+
+Simple, and adequate for "track what I spent". It cannot represent a transfer
+between two accounts without double-counting, and it has no concept of an
+account balance.
+
+### `/api/v1/finance/*` — the double-entry ledger
+
+Added later, this is a proper accounting model. The tenant root is
+`BudgetFile` (a user can have several; exactly one is the default):
+
+```
+User
+ └── BudgetFile                    (currency, is_default)
+      ├── Account                  (checking / savings / cash / credit / asset / liability)
+      ├── CategoryGroupV2
+      │    └── CategoryV2          (income / expense)
+      ├── Payee, Tag
+      ├── LedgerTransaction        (date, payee, memo, cleared, source_type)
+      │    └── LedgerPosting       (amount, and exactly one of account XOR category)
+      ├── BudgetMonth              (year, month, envelope or traditional)
+      │    └── EnvelopeAssignment  (assigned, carryover, goal)
+      ├── ScheduledTransaction     (recurrence + a transaction template)
+      ├── TransactionRule          (conditions + actions, JSON)
+      ├── SavedReport
+      ├── ImportJob, ExportJob, EncryptedBackupBundle
+      └── TransactionEvent         (append-only audit log)
+```
+
+**The core invariant: the postings of a transaction must sum to zero.** Buying
+£10 of groceries is two postings — `-10.00` against your checking account and
+`+10.00` against the Food category. A transfer is two *account* postings and no
+category, tied together by `transfer_group`.
+
+This is enforced in two places, which is worth knowing:
+
+- `LedgerPosting` has a database `CheckConstraint`
+  (`ledger_posting_exactly_one_target`) guaranteeing each posting references an
+  account **or** a category, never both and never neither.
+- The zero-sum rule is enforced in the serializer
+  (`finance_serializers._validate_postings`), not in the database.
+
+Business logic lives in `api/pft/finance_services.py`: balances and net worth,
+cash flow, spending trends, envelope snapshots, the rules engine, schedule
+materialisation, CSV/XLSX export, and importers for CSV, OFX, QFX, QIF,
+CAMT.053 and YNAB. Views stay thin and delegate to it.
+
+### How the two relate
+
+Both are live and routed at the same time. On signup, `pft/signals.py` seeds
+**both** trees: the ten legacy `Category` rows *and* a default `BudgetFile`, a
+"Cash" account, two category groups and ten `CategoryV2` rows. Nothing keeps
+them in sync afterwards.
+
+The web app reads through the legacy shapes but **writes to the finance API**.
+That translation lives in one file, `web/app/client/pft/v1/v1.ts`: it resolves
+the default budget file and account, maps a `LedgerTransaction` and its postings
+back into a flat `Transaction`, and splits a flat write back into balanced
+postings.
+
+That file is hand-written and lives next to — not inside — `web/app/client/gen/`,
+which is orval's output directory. Do not run `pnpm orval` expecting it to
+produce this; it will overwrite it with something that does not compile.
+
+### Where this is going
+
+The ledger model is the one to keep. The intended direction is:
+
+1. Move the UI onto `/api/v1/finance/*` directly, removing the adapter.
+2. Put a compatibility shim on `/api/v1/{transactions,categories,budgets}` with
+   a documented removal version, for anyone scripting against them.
+3. Rename `CategoryV2` and `CategoryGroupV2` — the "V2" suffix is an accident of
+   history that is currently baked into the public schema.
+
+Until then, when you add a feature: **add it to the finance domain.** The legacy
+endpoints are maintained, not extended.
+
+## Request lifecycle
+
+```
+Request
+  → corsheaders
+  → SecurityMiddleware, session, common, CSRF, auth, messages, clickjacking
+  → DRF view
+      → JWTAuthentication          (Authorization: Bearer <access>)
+      → IsAuthenticated
+      → ScopedRateThrottle         (login / register / password_change)
+      → get_queryset()             ← tenant scoping happens HERE
+      → serializer.validate_*()    ← ownership of referenced objects checked HERE
+      → finance_services.*         ← business logic
+```
+
+### Tenant scoping is per-viewset, and that is the risk
+
+`UserScopedModelViewSet` only sets `permission_classes = [IsAuthenticated]`.
+Despite the name, **it does not scope anything.** Every viewset is responsible
+for filtering its own queryset:
+
+```python
+# /api/v1/*        - the user owns the row directly
+Transaction.objects.filter(user=self.request.user)
+
+# /api/v1/finance/* - ownership is reached through the budget file
+Account.objects.filter(budget_file__user=self.request.user)
+LedgerPosting.objects.filter(transaction__budget_file__user=self.request.user)
+EnvelopeAssignment.objects.filter(budget_month__budget_file__user=self.request.user)
+```
+
+`LedgerPosting`, `LedgerTransactionTag`, `EnvelopeAssignment` and
+`TransactionEvent` have **no user column at all** — they rely entirely on that
+FK chain. One missing filter is a cross-tenant leak.
+
+Filtering the queryset is also not sufficient on its own. Any field that
+accepts an ID from the request body must be ownership-checked, or a user can
+point their own row at somebody else's object. Every past isolation bug in this
+codebase was of that shape.
+
+**This is why `api/pft/tests/test_tenant_isolation.py` exists, and why any change
+to a queryset, serializer or permission needs a test there.**
+
+## Frontend structure
+
+```
+web/app/
+├── main.tsx              root: router, SWR config, currency context, analytics
+├── app.tsx               route table and layout switch
+├── pages/                one directory per route
+├── components/           feature components
+│   └── ui/               shadcn primitives
+├── client/
+│   ├── httpPFTClient.ts  axios instance, auth header, 401 refresh-and-retry,
+│   │                     error toasts, offline mutation queue
+│   ├── pft/              hand-maintained API client (see above)
+│   └── gen/              orval output - generated, gitignored
+├── lib/                  auth (JWT cookies), finance-client, dates, analytics
+├── hooks/                Zustand stores
+└── context/              currency provider
+```
+
+Data fetching is SWR keyed on URL-ish strings. Note that global revalidation is
+switched off in `main.tsx`, so data refreshes on explicit mutation rather than
+on focus or reconnect.
+
+`web/app/lib/finance-client.ts` is a *second* hand-written client used by the
+reports and rules pages. It duplicates helpers from `client/pft/v1/v1.ts`,
+including a separate budget-file cache. Merging the two is a good contribution.
+
+## Authentication
+
+- `POST /api/token/` → `{access, refresh}`. Rate limited.
+- Access tokens last 5 minutes, refresh tokens 1 day, and refresh tokens rotate.
+- `POST /api/token/refresh/` returns a new pair and blacklists the old refresh
+  token.
+- `POST /api/token/logout/` blacklists one token, or every session with
+  `{"all": true}`. Changing a password blacklists everything.
+- The browser stores tokens in cookies written by JavaScript, with
+  `SameSite=Strict` and `Secure` on HTTPS. They are **not** HttpOnly, so an XSS
+  is an account takeover. Moving the access token into memory with an
+  HttpOnly refresh cookie is a known improvement.
+
+## Settings
+
+`api/app/settings/` splits into `base.py`, `dev.py` and `prod.py`. Containers
+run `prod` by default; `make dev` selects `dev`. Everything deployment-specific
+comes from the environment — see `.env.example` and `SECURITY.md`.
+
+`SECRET_KEY` is required in production. If unset, one is generated and persisted
+to `SECRET_KEY_FILE` on first boot so sessions survive a restart; the settings
+module refuses to fall back to any known placeholder.
+
+## Migrations
+
+`api/pft/migrations/` is a linear chain. `0002` creates nine models for an
+abandoned SaaS direction and `0003` deletes all nine — 240 lines that net to
+zero, kept only because rewriting history is not worth it. `0005` creates the
+entire finance domain and backfills existing v1 rows into it, marking them with
+`match_key="v1-<id>"`.
+
+Migrations are not reversible: the data migrations have no-op reverse functions.
+
+## Testing
+
+```
+api/pft/tests/
+├── test_api_smoke.py         registration, JWT, CRUD, filtering, pagination
+├── test_api_finance_v1.py    ledger, envelopes, reports, import/export, backups
+├── test_tenant_isolation.py  user B cannot read or write user A's data
+└── test_auth_hardening.py    logout, token revocation, throttling
+```
+
+There is no frontend test harness yet. Adding vitest plus one Playwright smoke
+path is a genuinely valuable contribution.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ fintrack/
 │   └── pft/   The application: models, views, serializers, services, tests
 ├── web/       React single-page app
 ├── landing/   Next.js marketing site (not part of the self-host stack)
-├── docs/      Feature audit artifacts
+├── docs/      Self-hosting guide and feature audit artifacts
 └── scripts/   Repo tooling
 ```
 
@@ -102,7 +102,7 @@ contribute, because the backend already works:
 
 **Not built yet:** account deletion, budget alerts and notifications, real
 multi-currency conversion, PWA offline mode, savings goals, investment tracking,
-native mobile apps.
+native mobile apps. See [ARCHITECTURE.md](ARCHITECTURE.md) for where things go.
 
 ---
 
@@ -159,12 +159,22 @@ Postgres is **not** published to the host by default; the port mapping in
 
 ---
 
+## 📚 Documentation
+
+| | |
+|---|---|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | How the system fits together, and why there are two API surfaces |
+| [docs/self-hosting.md](docs/self-hosting.md) | Reverse proxy, TLS, backups, upgrades, monitoring |
+| [SECURITY.md](SECURITY.md) | Hardening checklist, reporting, known limitations |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, conventions, good first issues |
+
+---
+
 ## 🔒 Security
 
-Read [SECURITY.md](SECURITY.md) before exposing an instance to the internet. It
+Read [SECURITY.md](SECURITY.md) and [docs/self-hosting.md](docs/self-hosting.md) before exposing an instance to the internet. It
 covers the hardening checklist, how to report a vulnerability privately, and the
-current known limitations (no rate limiting, no JWT revocation, unpaginated
-finance endpoints).
+current known limitations.
 
 If you ran a version of FinTrack from before this was fixed, note that a
 `SECRET_KEY` was previously committed to this repository and used as the default.
@@ -217,17 +227,25 @@ of work — see [CONTRIBUTING.md](CONTRIBUTING.md).
 Authentication is JWT: `POST /api/token/` to obtain a pair, `POST /api/token/refresh/`
 to refresh.
 
-> Note: `web/schema/pft.yaml` currently documents only the legacy surface. The live
-> schema at `/api/schema/` is generated from the code and is authoritative.
+`web/schema/pft.yaml` is generated from the backend and covers all 61 paths.
+Regenerate it after changing the API surface:
+
+```bash
+docker compose exec api uv run manage.py spectacular --file /tmp/schema.yaml
+```
 
 ---
 
 ## ⚠️ Known limitations
 
-- No rate limiting on login, registration or the Django admin.
-- JWTs cannot be revoked; a password change does not invalidate existing tokens.
-- The `/api/v1/finance/*` endpoints are not paginated.
-- Import and export run synchronously in the request, with no size cap.
+- The Django admin has no rate limiting of its own; limit it at your reverse
+  proxy, or don't expose it. The API throttles login, registration and password
+  changes.
+- The `/api/v1/finance/*` endpoints are not paginated, so a large ledger comes
+  back in one response.
+- Import and export run synchronously inside the request. Payloads are capped,
+  but there is no background queue.
+- Tokens live in JavaScript-readable cookies, so an XSS is an account takeover.
 - Currency selection changes the displayed symbol only — it does not convert.
 - Transaction filtering and sorting in the UI operate on the current page.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,15 +45,20 @@ deployment. At minimum:
 
 These are real and tracked, not hidden:
 
-- **No rate limiting** on `/api/token/`, `/api/v1/register/` or `/admin/login/`.
-  Put a reverse proxy with rate limiting in front of a public instance.
-- **JWTs cannot be revoked.** There is no token blacklist and no logout endpoint;
-  changing a password does not invalidate outstanding tokens. Access tokens live
-  5 minutes, refresh tokens 1 day.
+- **`/admin/login/` is not rate limited.** The API throttles `/api/token/`,
+  `/api/v1/register/` and password changes, but the Django admin login is
+  served by Django itself. Limit it at your reverse proxy, or do not expose it.
 - **Tokens are stored in JavaScript-readable cookies**, so any XSS is an account
-  takeover.
-- **Import and export run synchronously in the request** with no size cap, and
-  `ImportJob.source_payload` retains the raw uploaded bank file in the database.
+  takeover. They carry `SameSite=Strict`, and `Secure` over HTTPS, but not
+  `HttpOnly`. Moving the access token into memory with an HttpOnly refresh
+  cookie is planned.
+- **Import and export run synchronously in the request.** Payloads are capped
+  (`FINTRACK_MAX_IMPORT_BYTES`, `FINTRACK_MAX_BACKUP_BYTES`) but there is no
+  background queue, so a large import ties up a worker.
+- **`ImportJob.source_payload` retains the raw uploaded bank file** in the
+  database as plaintext, as do completed exports. Run
+  `manage.py prune_finance_jobs` periodically; see
+  [docs/self-hosting.md](docs/self-hosting.md).
 - **The finance endpoints are unpaginated**, so a large ledger returns in one
   response.
 

--- a/docs/feature-audit/parity-report.md
+++ b/docs/feature-audit/parity-report.md
@@ -22,9 +22,7 @@ Matrix validation errors:
 
 ## Parity Findings
 
-| Severity | Finding | Detail | Evidence |
-|---|---|---|---|
-| P2 | Backend routes missing from OpenAPI schema | 31 active endpoints are not represented in schema. | `api/pft/routers.py`<br>`api/pft/urls.py`<br>`web/schema/pft.yaml` |
+No parity findings.
 
 
 ## Schema Endpoints Not in Active Backend
@@ -34,35 +32,5 @@ Matrix validation errors:
 
 ## Active Backend Endpoints Missing From Schema
 
-- `/api/v1/finance/`
-- `/api/v1/finance/accounts/`
-- `/api/v1/finance/accounts/{id}/`
-- `/api/v1/finance/backups/`
-- `/api/v1/finance/backups/{id}/`
-- `/api/v1/finance/budget-files/`
-- `/api/v1/finance/budget-files/{id}/`
-- `/api/v1/finance/budget-months/`
-- `/api/v1/finance/budget-months/{id}/`
-- `/api/v1/finance/categories/`
-- `/api/v1/finance/categories/{id}/`
-- `/api/v1/finance/category-groups/`
-- `/api/v1/finance/category-groups/{id}/`
-- `/api/v1/finance/envelope-assignments/`
-- `/api/v1/finance/envelope-assignments/{id}/`
-- `/api/v1/finance/exports/`
-- `/api/v1/finance/exports/{id}/`
-- `/api/v1/finance/imports/`
-- `/api/v1/finance/imports/{id}/`
-- `/api/v1/finance/payees/`
-- `/api/v1/finance/payees/{id}/`
-- `/api/v1/finance/postings/`
-- `/api/v1/finance/postings/{id}/`
-- `/api/v1/finance/reports/`
-- `/api/v1/finance/reports/{id}/`
-- `/api/v1/finance/rules/`
-- `/api/v1/finance/rules/{id}/`
-- `/api/v1/finance/tags/`
-- `/api/v1/finance/tags/{id}/`
-- `/api/v1/finance/transactions/`
-- `/api/v1/finance/transactions/{id}/`
+- None
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,239 @@
+# Self-hosting FinTrack
+
+The quickstart in the README gets you a working instance on your own machine.
+This guide covers everything after that: putting it on a real host, backing it
+up, and upgrading it.
+
+Read [SECURITY.md](../SECURITY.md) alongside this. It lists the current known
+limitations, and they affect how you should deploy.
+
+## Before you expose it
+
+The defaults are tuned for a local trial. For anything reachable beyond your
+laptop, edit `.env`:
+
+```bash
+# 1. A real signing key. Keep it stable; changing it signs everyone out.
+SECRET_KEY=$(openssl rand -base64 48)
+
+# 2. A real database password.
+POSTGRES_PASSWORD=<something long>
+
+# 3. Your own hostname.
+DJANGO_ALLOWED_HOSTS=fintrack.example.com
+CORS_ALLOWED_ORIGINS=https://fintrack.example.com
+CSRF_TRUSTED_ORIGINS=https://fintrack.example.com
+
+# 4. TLS terminates in front of the stack.
+SECURE_SSL=True
+```
+
+Then:
+
+```bash
+docker compose up -d
+```
+
+Set `SECURE_SSL=False` only when you are deliberately serving plain HTTP, for
+example on a home LAN. With it `True` and no TLS in front, Django will redirect
+you into a loop.
+
+## Running behind a reverse proxy
+
+The `web` container serves the UI on port 80 and proxies `/api/` to the backend
+internally, so you only need to expose one port. Point your proxy at
+`WEB_PORT` (default 5173) and terminate TLS there.
+
+### Caddy
+
+```caddyfile
+fintrack.example.com {
+    reverse_proxy localhost:5173
+}
+```
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name fintrack.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/fintrack.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/fintrack.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:5173;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Imports and exports are computed synchronously.
+        proxy_read_timeout 300s;
+        client_max_body_size 20m;
+    }
+}
+```
+
+`X-Forwarded-Proto` matters: Django uses it to know the request arrived over
+HTTPS.
+
+### Rate limiting at the edge
+
+The API throttles login, registration and password changes, but there is no
+protection on `/admin/`. If you expose the Django admin at all, rate limit it
+in your proxy — or better, do not expose it:
+
+```nginx
+location /admin/ {
+    allow 10.0.0.0/8;
+    deny all;
+    proxy_pass http://127.0.0.1:5173;
+}
+```
+
+## Creating your account
+
+There is no default admin and no default password.
+
+The simplest path is to register through the UI — the first account you create
+is a normal user, which is all you need to use FinTrack.
+
+For a Django admin account:
+
+```bash
+docker compose exec api uv run manage.py createsuperuser
+```
+
+Or non-interactively, before the first start, in `.env`:
+
+```bash
+FINTRACK_ADMIN_EMAIL=you@example.com
+FINTRACK_ADMIN_PASSWORD=<a real password>
+```
+
+Both must be set, and the password must pass Django's validators.
+
+## Demo data
+
+To see the app populated — for a screenshot, a demo, or just to judge whether
+you like it:
+
+```bash
+docker compose exec api uv run manage.py seed_demo
+```
+
+That creates `demo@fintrack.local` with six months of transactions, two
+accounts and envelope budgets. Re-run with `--reset` to rebuild it, and delete
+the user when you are done.
+
+## Backups
+
+Your data lives in the `postgres_data` volume. Nothing else in the stack holds
+state you cannot rebuild.
+
+### Dumping
+
+```bash
+docker compose exec -T db pg_dump -U fintrack fintrack | gzip > fintrack-$(date +%F).sql.gz
+```
+
+Automate it with cron:
+
+```cron
+0 3 * * * cd /srv/fintrack && docker compose exec -T db pg_dump -U fintrack fintrack | gzip > /backups/fintrack-$(date +\%F).sql.gz
+```
+
+### Restoring
+
+Restoring overwrites the current database. Stop the app first so nothing writes
+during the restore:
+
+```bash
+docker compose stop api web
+```
+
+```bash
+gunzip -c fintrack-2026-08-12.sql.gz | docker compose exec -T db psql -U fintrack -d fintrack
+```
+
+```bash
+docker compose start api web
+```
+
+Back up your `.env` too — specifically `SECRET_KEY`. Restoring a database with a
+different signing key invalidates every session and token.
+
+### Application-level backups
+
+The API also has an encrypted backup bundle endpoint
+(`/api/v1/finance/backups/`), which stores a client-encrypted archive. It is
+not yet exposed in the UI, and it is not a substitute for a database dump.
+
+## Upgrading
+
+```bash
+cd /srv/fintrack
+```
+
+```bash
+git pull && docker compose build && docker compose up -d
+```
+
+Migrations run automatically: the `migrate` service executes before `api`
+starts, and `api` waits for it to complete.
+
+**Take a database dump before upgrading.** Migrations in this project are not
+reversible — the data migrations have no-op reverse functions — so rolling back
+means restoring a dump.
+
+Watch it come up:
+
+```bash
+docker compose logs -f migrate api
+```
+
+## Housekeeping
+
+Import and export jobs retain their payloads in the database, and those
+payloads are plaintext financial data. Clear old ones periodically:
+
+```bash
+docker compose exec api uv run manage.py prune_finance_jobs --days 30
+```
+
+Add `--dry-run` to see what it would clear.
+
+## Monitoring
+
+`/healthz/` returns `200` with `{"status": "ok", "database": "ok"}` when the API
+can reach Postgres, and `503` otherwise. It is unauthenticated and contains no
+user data, so it is safe to point an uptime monitor at.
+
+```bash
+curl -fsS https://fintrack.example.com/healthz/
+```
+
+Container health is wired into compose, so `docker compose ps` shows real
+status rather than just "running".
+
+## Troubleshooting
+
+**The stack starts but the web app cannot reach the API.** Check
+`CORS_ALLOWED_ORIGINS` matches the scheme and host you are actually browsing
+from, including the port if it is non-standard.
+
+**Redirect loop after enabling TLS.** Your proxy is not sending
+`X-Forwarded-Proto: https`, so Django thinks the request is plain HTTP and
+redirects again.
+
+**`DisallowedHost` errors.** Add your hostname to `DJANGO_ALLOWED_HOSTS`. It
+accepts spaces or commas as separators.
+
+**Everyone was signed out after a restart.** `SECRET_KEY` was not set, so a new
+one was generated. Set it explicitly in `.env`.
+
+**Compose keeps starting an old version.** The compose file sets
+`pull_policy: build` so it builds from your checkout, but a previously pulled
+image can still be cached — `docker compose build --no-cache` settles it.

--- a/scripts/feature_audit.py
+++ b/scripts/feature_audit.py
@@ -18,6 +18,8 @@ REPORT_PATH = ROOT / "docs/feature-audit/parity-report.md"
 SCHEMA_PATH = ROOT / "web/schema/pft.yaml"
 ROUTERS_PATH = ROOT / "api/pft/routers.py"
 FINANCE_ROUTERS_PATH = ROOT / "api/pft/finance_routers.py"
+VIEWS_PATH = ROOT / "api/pft/views.py"
+FINANCE_VIEWS_PATH = ROOT / "api/pft/finance_views.py"
 PFT_URLS_PATH = ROOT / "api/pft/urls.py"
 APP_URLS_PATH = ROOT / "api/app/urls.py"
 TRANSACTIONS_PAGE_PATH = ROOT / "web/app/pages/transactions/index.tsx"
@@ -141,27 +143,78 @@ def extract_schema_endpoints() -> set[str]:
     return endpoints
 
 
+# `router.register(` may wrap across lines, so allow whitespace before the prefix.
+REGISTER_RE = re.compile(r'router\.register\(\s*"([^"]+)"\s*,\s*(\w+)')
+# @action(detail=..., url_path="...") declares an extra route on a viewset.
+ACTION_RE = re.compile(r"@action\((?P<args>[^)]*)\)", re.S)
+
+
+def _actions_for(source: str) -> dict[str, list[tuple[bool, str]]]:
+    """Collect @action routes per viewset, tolerating multi-line decorators."""
+    actions: dict[str, list[tuple[bool, str]]] = {}
+    class_positions = [
+        (match.start(), match.group(1)) for match in re.finditer(r"^class (\w+)\(", source, re.M)
+    ]
+
+    for match in ACTION_RE.finditer(source):
+        args = match.group("args")
+        url_match = re.search(r'url_path="([^"]+)"', args)
+        if not url_match:
+            continue
+        owner = None
+        for position, name in class_positions:
+            if position < match.start():
+                owner = name
+            else:
+                break
+        if owner is None:
+            continue
+        actions.setdefault(owner, []).append(("detail=True" in args, url_match.group(1)))
+
+    return actions
+
+
+def _register_router(endpoints: set[str], source: str, prefix: str, actions_source: str) -> None:
+    actions = _actions_for(actions_source)
+    for resource, viewset in REGISTER_RE.findall(source):
+        endpoints.add(f"{prefix}/{resource}/")
+        endpoints.add(f"{prefix}/{resource}/{{id}}/")
+        for detail, url_path in actions.get(viewset, []):
+            if detail:
+                endpoints.add(f"{prefix}/{resource}/{{id}}/{url_path}/")
+            else:
+                endpoints.add(f"{prefix}/{resource}/{url_path}/")
+
+
 def extract_backend_endpoints() -> set[str]:
     endpoints: set[str] = set()
 
     app_urls = APP_URLS_PATH.read_text(encoding="utf-8")
-    for match in re.finditer(r'path\("([^"]+)"', app_urls):
+    # Skip include() mounts: they are prefixes, not endpoints. The resources
+    # behind them are picked up from the routers below.
+    for match in re.finditer(r'path\(\s*"([^"]+)"\s*,\s*(?P<target>[^,)]+)', app_urls):
         path_value = match.group(1)
-        if path_value.startswith("api/") and path_value != "api/v1/":
+        if "include(" in match.group("target"):
+            continue
+        if path_value.startswith("api/"):
             endpoints.add("/" + path_value)
 
-    routers = ROUTERS_PATH.read_text(encoding="utf-8")
-    for resource in re.findall(r'router\.register\("([^"]+)"', routers):
-        endpoints.add(f"/api/v1/{resource}/")
-        endpoints.add(f"/api/v1/{resource}/{{id}}/")
+    _register_router(
+        endpoints,
+        ROUTERS_PATH.read_text(encoding="utf-8"),
+        "/api/v1",
+        VIEWS_PATH.read_text(encoding="utf-8"),
+    )
 
-    # The finance domain mounts 16 more resources under /api/v1/finance/.
-    # Omitting this file was why the parity report reported PASS while the
-    # entire API the UI actually calls was undocumented.
-    finance_routers = FINANCE_ROUTERS_PATH.read_text(encoding="utf-8")
-    for resource in re.findall(r'router\.register\("([^"]+)"', finance_routers):
-        endpoints.add(f"/api/v1/finance/{resource}/")
-        endpoints.add(f"/api/v1/finance/{resource}/{{id}}/")
+    # The finance domain mounts 16 more resources under /api/v1/finance/, each
+    # with its own @action routes. Omitting this file was why the parity report
+    # reported PASS while the entire API the UI calls was undocumented.
+    _register_router(
+        endpoints,
+        FINANCE_ROUTERS_PATH.read_text(encoding="utf-8"),
+        "/api/v1/finance",
+        FINANCE_VIEWS_PATH.read_text(encoding="utf-8"),
+    )
 
     pft_urls = PFT_URLS_PATH.read_text(encoding="utf-8")
     for match in re.finditer(r'path\("([^"]+)"', pft_urls):

--- a/web/schema/pft.yaml
+++ b/web/schema/pft.yaml
@@ -7,688 +7,4879 @@ paths:
   /api/token/:
     post:
       operationId: token_create
+      description: Login, rate limited per IP so the password field cannot be brute
+        forced.
       tags:
-        - auth
+      - token
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenObtainPairRequest'
+              $ref: '#/components/schemas/TokenObtainPair'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+        required: true
       responses:
         '200':
-          description: JWT token pair
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenObtainPairResponse'
+                $ref: '#/components/schemas/TokenObtainPair'
+          description: ''
+  /api/token/logout/:
+    post:
+      operationId: token_logout_create
+      description: |-
+        Revoke a refresh token.
+
+        POST {"refresh": "<token>"} revokes that token. POST {"all": true} revokes
+        every session for the current user.
+      tags:
+      - token
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/token/refresh/:
     post:
       operationId: token_refresh_create
+      description: |-
+        Takes a refresh type JSON web token and returns an access type JSON web
+        token if the refresh token is valid.
       tags:
-        - auth
+      - token
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenRefreshRequest'
-      responses:
-        '200':
-          description: Refreshed access token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TokenRefreshResponse'
-  /api/v1/register/:
-    post:
-      operationId: v1_register_create
-      tags:
-        - v1
-      requestBody:
-        required: true
-        content:
-          application/json:
+              $ref: '#/components/schemas/TokenRefresh'
+          application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/RegisterRequest'
-      responses:
-        '201':
-          description: User registered
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegisterResponse'
-  /api/v1/me/:
-    get:
-      operationId: v1_me_retrieve
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      responses:
-        '200':
-          description: Current user profile
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserProfile'
-  /api/v1/profile/update/:
-    put:
-      operationId: v1_profile_update_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
+              $ref: '#/components/schemas/TokenRefresh'
+          multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UserProfileUpdateRequest'
-      responses:
-        '200':
-          description: Updated profile
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserProfile'
-    patch:
-      operationId: v1_profile_update_partial_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
+              $ref: '#/components/schemas/TokenRefresh'
         required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserProfileUpdateRequest'
       responses:
         '200':
-          description: Updated profile
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserProfile'
-  /api/v1/profile/change-password/:
-    post:
-      operationId: v1_profile_change_password_create
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChangePasswordRequest'
-      responses:
-        '200':
-          description: Password changed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
-  /api/v1/categories/:
-    get:
-      operationId: v1_categories_list
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      parameters:
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: Category list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedCategoryList'
-    post:
-      operationId: v1_categories_create
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CategoryRequest'
-      responses:
-        '201':
-          description: Category created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Category'
-  /api/v1/categories/{id}/:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: v1_categories_retrieve
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      responses:
-        '200':
-          description: Category
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Category'
-    put:
-      operationId: v1_categories_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CategoryRequest'
-      responses:
-        '200':
-          description: Category updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Category'
-    patch:
-      operationId: v1_categories_partial_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CategoryRequest'
-      responses:
-        '200':
-          description: Category updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Category'
-    delete:
-      operationId: v1_categories_destroy
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      responses:
-        '204':
-          description: Category deleted
-  /api/v1/transactions/:
-    get:
-      operationId: v1_transactions_list
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      parameters:
-        - name: ordering
-          in: query
-          required: false
-          schema:
-            type: string
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-        - name: search
-          in: query
-          required: false
-          schema:
-            type: string
-        - name: start_date
-          in: query
-          required: false
-          schema:
-            type: string
-            format: date
-        - name: end_date
-          in: query
-          required: false
-          schema:
-            type: string
-            format: date
-      responses:
-        '200':
-          description: Transaction list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedTransactionList'
-    post:
-      operationId: v1_transactions_create
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransactionRequest'
-      responses:
-        '201':
-          description: Transaction created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Transaction'
-  /api/v1/transactions/{id}/:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: v1_transactions_retrieve
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      responses:
-        '200':
-          description: Transaction
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Transaction'
-    put:
-      operationId: v1_transactions_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransactionRequest'
-      responses:
-        '200':
-          description: Transaction updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Transaction'
-    patch:
-      operationId: v1_transactions_partial_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransactionRequest'
-      responses:
-        '200':
-          description: Transaction updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Transaction'
-    delete:
-      operationId: v1_transactions_destroy
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      responses:
-        '204':
-          description: Transaction deleted
+                $ref: '#/components/schemas/TokenRefresh'
+          description: ''
   /api/v1/budgets/:
     get:
       operationId: v1_budgets_list
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
       parameters:
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
       responses:
         '200':
-          description: Budget list
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedBudgetList'
+          description: ''
     post:
       operationId: v1_budgets_create
       tags:
-        - v1
-      security:
-        - jwtAuth: []
+      - v1
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BudgetRequest'
+              $ref: '#/components/schemas/Budget'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Budget'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Budget'
+        required: true
+      security:
+      - jwtAuth: []
       responses:
         '201':
-          description: Budget created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
+          description: ''
   /api/v1/budgets/{id}/:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
     get:
       operationId: v1_budgets_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
       tags:
-        - v1
+      - v1
       security:
-        - jwtAuth: []
+      - jwtAuth: []
       responses:
         '200':
-          description: Budget
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
+          description: ''
     put:
       operationId: v1_budgets_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
         required: true
+      tags:
+      - v1
+      requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BudgetRequest'
+              $ref: '#/components/schemas/Budget'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Budget'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Budget'
+        required: true
+      security:
+      - jwtAuth: []
       responses:
         '200':
-          description: Budget updated
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
+          description: ''
     patch:
       operationId: v1_budgets_partial_update
-      tags:
-        - v1
-      security:
-        - jwtAuth: []
-      requestBody:
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
         required: true
+      tags:
+      - v1
+      requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BudgetRequest'
+              $ref: '#/components/schemas/PatchedBudget'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedBudget'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedBudget'
+      security:
+      - jwtAuth: []
       responses:
         '200':
-          description: Budget updated
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
+          description: ''
     delete:
       operationId: v1_budgets_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
       tags:
-        - v1
+      - v1
       security:
-        - jwtAuth: []
+      - jwtAuth: []
       responses:
         '204':
-          description: Budget deleted
+          description: No response body
+  /api/v1/categories/:
+    get:
+      operationId: v1_categories_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryList'
+          description: ''
+    post:
+      operationId: v1_categories_create
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Category'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Category'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Category'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+  /api/v1/categories/{id}/:
+    get:
+      operationId: v1_categories_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+    put:
+      operationId: v1_categories_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Category'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Category'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Category'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+    patch:
+      operationId: v1_categories_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCategory'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCategory'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCategory'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+    delete:
+      operationId: v1_categories_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/accounts/:
+    get:
+      operationId: v1_finance_accounts_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Account'
+          description: ''
+    post:
+      operationId: v1_finance_accounts_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Account'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Account'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Account'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: ''
+  /api/v1/finance/accounts/{id}/:
+    get:
+      operationId: v1_finance_accounts_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: ''
+    put:
+      operationId: v1_finance_accounts_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Account'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Account'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Account'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: ''
+    patch:
+      operationId: v1_finance_accounts_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedAccount'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedAccount'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedAccount'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: ''
+    delete:
+      operationId: v1_finance_accounts_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/backups/:
+    get:
+      operationId: v1_finance_backups_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+    post:
+      operationId: v1_finance_backups_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+  /api/v1/finance/backups/{id}/:
+    get:
+      operationId: v1_finance_backups_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+    put:
+      operationId: v1_finance_backups_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EncryptedBackupBundle'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+    patch:
+      operationId: v1_finance_backups_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedEncryptedBackupBundle'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedEncryptedBackupBundle'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedEncryptedBackupBundle'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+    delete:
+      operationId: v1_finance_backups_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/backups/latest/:
+    get:
+      operationId: v1_finance_backups_latest_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptedBackupBundle'
+          description: ''
+  /api/v1/finance/budget-files/:
+    get:
+      operationId: v1_finance_budget_files_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BudgetFile'
+          description: ''
+    post:
+      operationId: v1_finance_budget_files_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+  /api/v1/finance/budget-files/{id}/:
+    get:
+      operationId: v1_finance_budget_files_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+    put:
+      operationId: v1_finance_budget_files_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+    patch:
+      operationId: v1_finance_budget_files_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetFile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetFile'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+    delete:
+      operationId: v1_finance_budget_files_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/budget-files/{id}/balances/:
+    get:
+      operationId: v1_finance_budget_files_balances_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+  /api/v1/finance/budget-files/{id}/set-default/:
+    post:
+      operationId: v1_finance_budget_files_set_default_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetFile'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetFile'
+          description: ''
+  /api/v1/finance/budget-months/:
+    get:
+      operationId: v1_finance_budget_months_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+    post:
+      operationId: v1_finance_budget_months_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+  /api/v1/finance/budget-months/{id}/:
+    get:
+      operationId: v1_finance_budget_months_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+    put:
+      operationId: v1_finance_budget_months_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+    patch:
+      operationId: v1_finance_budget_months_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedBudgetMonth'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+    delete:
+      operationId: v1_finance_budget_months_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/budget-months/{id}/copy-previous/:
+    post:
+      operationId: v1_finance_budget_months_copy_previous_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+  /api/v1/finance/budget-months/{id}/snapshot/:
+    get:
+      operationId: v1_finance_budget_months_snapshot_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+  /api/v1/finance/budget-months/{id}/three-month-average/:
+    post:
+      operationId: v1_finance_budget_months_three_month_average_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+  /api/v1/finance/budget-months/{id}/zero-out/:
+    post:
+      operationId: v1_finance_budget_months_zero_out_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BudgetMonth'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetMonth'
+          description: ''
+  /api/v1/finance/categories/:
+    get:
+      operationId: v1_finance_categories_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CategoryV2'
+          description: ''
+    post:
+      operationId: v1_finance_categories_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryV2'
+          description: ''
+  /api/v1/finance/categories/{id}/:
+    get:
+      operationId: v1_finance_categories_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryV2'
+          description: ''
+    put:
+      operationId: v1_finance_categories_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CategoryV2'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryV2'
+          description: ''
+    patch:
+      operationId: v1_finance_categories_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryV2'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryV2'
+          description: ''
+    delete:
+      operationId: v1_finance_categories_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/category-groups/:
+    get:
+      operationId: v1_finance_category_groups_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CategoryGroupV2'
+          description: ''
+    post:
+      operationId: v1_finance_category_groups_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupV2'
+          description: ''
+  /api/v1/finance/category-groups/{id}/:
+    get:
+      operationId: v1_finance_category_groups_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupV2'
+          description: ''
+    put:
+      operationId: v1_finance_category_groups_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CategoryGroupV2'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupV2'
+          description: ''
+    patch:
+      operationId: v1_finance_category_groups_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryGroupV2'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryGroupV2'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCategoryGroupV2'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryGroupV2'
+          description: ''
+    delete:
+      operationId: v1_finance_category_groups_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/envelope-assignments/:
+    get:
+      operationId: v1_finance_envelope_assignments_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvelopeAssignment'
+          description: ''
+    post:
+      operationId: v1_finance_envelope_assignments_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvelopeAssignment'
+          description: ''
+  /api/v1/finance/envelope-assignments/{id}/:
+    get:
+      operationId: v1_finance_envelope_assignments_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvelopeAssignment'
+          description: ''
+    put:
+      operationId: v1_finance_envelope_assignments_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EnvelopeAssignment'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvelopeAssignment'
+          description: ''
+    patch:
+      operationId: v1_finance_envelope_assignments_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedEnvelopeAssignment'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedEnvelopeAssignment'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedEnvelopeAssignment'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvelopeAssignment'
+          description: ''
+    delete:
+      operationId: v1_finance_envelope_assignments_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/exports/:
+    get:
+      operationId: v1_finance_exports_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExportJob'
+          description: ''
+    post:
+      operationId: v1_finance_exports_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+          description: ''
+  /api/v1/finance/exports/{id}/:
+    get:
+      operationId: v1_finance_exports_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+          description: ''
+    put:
+      operationId: v1_finance_exports_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ExportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+          description: ''
+    patch:
+      operationId: v1_finance_exports_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedExportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedExportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedExportJob'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+          description: ''
+    delete:
+      operationId: v1_finance_exports_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/exports/{id}/download/:
+    get:
+      operationId: v1_finance_exports_download_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportJob'
+          description: ''
+  /api/v1/finance/imports/:
+    get:
+      operationId: v1_finance_imports_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ImportJob'
+          description: ''
+    post:
+      operationId: v1_finance_imports_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+  /api/v1/finance/imports/{id}/:
+    get:
+      operationId: v1_finance_imports_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+    put:
+      operationId: v1_finance_imports_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+    patch:
+      operationId: v1_finance_imports_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedImportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedImportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedImportJob'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+    delete:
+      operationId: v1_finance_imports_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/imports/{id}/execute/:
+    post:
+      operationId: v1_finance_imports_execute_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+  /api/v1/finance/imports/{id}/preview/:
+    post:
+      operationId: v1_finance_imports_preview_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+          description: ''
+  /api/v1/finance/payees/:
+    get:
+      operationId: v1_finance_payees_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payee'
+          description: ''
+    post:
+      operationId: v1_finance_payees_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Payee'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Payee'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Payee'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payee'
+          description: ''
+  /api/v1/finance/payees/{id}/:
+    get:
+      operationId: v1_finance_payees_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payee'
+          description: ''
+    put:
+      operationId: v1_finance_payees_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Payee'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Payee'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Payee'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payee'
+          description: ''
+    patch:
+      operationId: v1_finance_payees_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPayee'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPayee'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPayee'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payee'
+          description: ''
+    delete:
+      operationId: v1_finance_payees_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/postings/:
+    get:
+      operationId: v1_finance_postings_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LedgerPostingRead'
+          description: ''
+  /api/v1/finance/postings/{id}/:
+    get:
+      operationId: v1_finance_postings_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerPostingRead'
+          description: ''
+  /api/v1/finance/reports/:
+    get:
+      operationId: v1_finance_reports_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SavedReport'
+          description: ''
+    post:
+      operationId: v1_finance_reports_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+  /api/v1/finance/reports/{id}/:
+    get:
+      operationId: v1_finance_reports_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+    put:
+      operationId: v1_finance_reports_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+    patch:
+      operationId: v1_finance_reports_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSavedReport'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedSavedReport'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedSavedReport'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+    delete:
+      operationId: v1_finance_reports_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/reports/{id}/run/:
+    post:
+      operationId: v1_finance_reports_run_create_2
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+  /api/v1/finance/reports/run/:
+    post:
+      operationId: v1_finance_reports_run_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SavedReport'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedReport'
+          description: ''
+  /api/v1/finance/rules/:
+    get:
+      operationId: v1_finance_rules_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransactionRule'
+          description: ''
+    post:
+      operationId: v1_finance_rules_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionRule'
+          description: ''
+  /api/v1/finance/rules/{id}/:
+    get:
+      operationId: v1_finance_rules_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionRule'
+          description: ''
+    put:
+      operationId: v1_finance_rules_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionRule'
+          description: ''
+    patch:
+      operationId: v1_finance_rules_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTransactionRule'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTransactionRule'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTransactionRule'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionRule'
+          description: ''
+    delete:
+      operationId: v1_finance_rules_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/rules/apply/:
+    post:
+      operationId: v1_finance_rules_apply_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TransactionRule'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionRule'
+          description: ''
+  /api/v1/finance/scheduled-transactions/:
+    get:
+      operationId: v1_finance_scheduled_transactions_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+    post:
+      operationId: v1_finance_scheduled_transactions_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+  /api/v1/finance/scheduled-transactions/{id}/:
+    get:
+      operationId: v1_finance_scheduled_transactions_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+    put:
+      operationId: v1_finance_scheduled_transactions_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+    patch:
+      operationId: v1_finance_scheduled_transactions_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedScheduledTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedScheduledTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedScheduledTransaction'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+    delete:
+      operationId: v1_finance_scheduled_transactions_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/scheduled-transactions/run-due/:
+    post:
+      operationId: v1_finance_scheduled_transactions_run_due_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScheduledTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduledTransaction'
+          description: ''
+  /api/v1/finance/tags/:
+    get:
+      operationId: v1_finance_tags_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tag'
+          description: ''
+    post:
+      operationId: v1_finance_tags_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tag'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Tag'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Tag'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+          description: ''
+  /api/v1/finance/tags/{id}/:
+    get:
+      operationId: v1_finance_tags_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+          description: ''
+    put:
+      operationId: v1_finance_tags_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tag'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Tag'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Tag'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+          description: ''
+    patch:
+      operationId: v1_finance_tags_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTag'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTag'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTag'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+          description: ''
+    delete:
+      operationId: v1_finance_tags_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/transactions/:
+    get:
+      operationId: v1_finance_transactions_list
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+    post:
+      operationId: v1_finance_transactions_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+  /api/v1/finance/transactions/{id}/:
+    get:
+      operationId: v1_finance_transactions_retrieve
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+    put:
+      operationId: v1_finance_transactions_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+    patch:
+      operationId: v1_finance_transactions_partial_update
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedLedgerTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedLedgerTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedLedgerTransaction'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+    delete:
+      operationId: v1_finance_transactions_destroy
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/v1/finance/transactions/{id}/apply-rules/:
+    post:
+      operationId: v1_finance_transactions_apply_rules_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+  /api/v1/finance/transactions/bulk-update/:
+    post:
+      operationId: v1_finance_transactions_bulk_update_create
+      description: |-
+        Base class for the finance viewsets.
+
+        NOTE: this only enforces authentication. Every subclass is still responsible
+        for scoping its own get_queryset() to request.user.
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LedgerTransaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerTransaction'
+          description: ''
+  /api/v1/me/:
+    get:
+      operationId: v1_me_retrieve
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/v1/profile/change-password/:
+    post:
+      operationId: v1_profile_change_password_create
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/v1/profile/update/:
+    put:
+      operationId: v1_profile_update_update
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserProfile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserProfile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserProfile'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+          description: ''
+    patch:
+      operationId: v1_profile_update_partial_update
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfile'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfile'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+          description: ''
+  /api/v1/register/:
+    post:
+      operationId: v1_register_create
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRegistration'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserRegistration'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserRegistration'
+        required: true
+      security:
+      - jwtAuth: []
+      - {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRegistration'
+          description: ''
+  /api/v1/transactions/:
+    get:
+      operationId: v1_transactions_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTransactionList'
+          description: ''
+    post:
+      operationId: v1_transactions_create
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          description: ''
+  /api/v1/transactions/{id}/:
+    get:
+      operationId: v1_transactions_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          description: ''
+    put:
+      operationId: v1_transactions_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Transaction'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          description: ''
+    patch:
+      operationId: v1_transactions_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTransaction'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTransaction'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTransaction'
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          description: ''
+    delete:
+      operationId: v1_transactions_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No response body
 components:
-  securitySchemes:
-    jwtAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
   schemas:
-    TypeEnum:
-      type: string
-      enum:
-        - income
-        - expense
-    DepartmentEnum:
-      type: string
-      enum:
-        - engineering
-        - finance
-        - hr
-        - marketing
-        - sales
-        - other
-    RoleEnum:
-      type: string
-      enum:
-        - admin
-        - manager
-        - employee
-    TokenObtainPairRequest:
+    Account:
       type: object
-      required:
-        - email
-        - password
-      properties:
-        email:
-          type: string
-          format: email
-        password:
-          type: string
-    TokenObtainPairResponse:
-      type: object
-      required:
-        - access
-        - refresh
-      properties:
-        access:
-          type: string
-        refresh:
-          type: string
-    TokenRefreshRequest:
-      type: object
-      required:
-        - refresh
-      properties:
-        refresh:
-          type: string
-    TokenRefreshResponse:
-      type: object
-      required:
-        - access
-      properties:
-        access:
-          type: string
-    RegisterRequest:
-      type: object
-      required:
-        - email
-        - password
-        - confirm_password
-      properties:
-        email:
-          type: string
-          format: email
-        username:
-          type: string
-        password:
-          type: string
-        confirm_password:
-          type: string
-        first_name:
-          type: string
-        last_name:
-          type: string
-        phone_number:
-          type: string
-        location:
-          type: string
-        bio:
-          type: string
-        department:
-          $ref: '#/components/schemas/DepartmentEnum'
-    RegisterResponse:
-      type: object
-      properties:
-        email:
-          type: string
-          format: email
-        username:
-          type: string
-        first_name:
-          type: string
-        last_name:
-          type: string
-        phone_number:
-          type: string
-        location:
-          type: string
-        bio:
-          type: string
-        department:
-          $ref: '#/components/schemas/DepartmentEnum'
-    UserProfile:
-      type: object
-      required:
-        - id
-        - email
-        - role
       properties:
         id:
           type: integer
-        email:
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
           type: string
-          format: email
-        first_name:
+          maxLength: 120
+        type:
+          $ref: '#/components/schemas/AccountTypeEnum'
+        opening_balance:
           type: string
-        last_name:
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        current_balance:
           type: string
-        phone_number:
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+          readOnly: true
+        is_archived:
+          type: boolean
+        created_at:
           type: string
-        location:
+          format: date-time
+          readOnly: true
+        updated_at:
           type: string
-        bio:
-          type: string
-        department:
-          $ref: '#/components/schemas/DepartmentEnum'
-        role:
-          $ref: '#/components/schemas/RoleEnum'
-    UserProfileUpdateRequest:
-      type: object
-      properties:
-        first_name:
-          type: string
-        last_name:
-          type: string
-        phone_number:
-          type: string
-        location:
-          type: string
-        bio:
-          type: string
-        department:
-          $ref: '#/components/schemas/DepartmentEnum'
-    ChangePasswordRequest:
-      type: object
+          format: date-time
+          readOnly: true
       required:
-        - current_password
-        - new_password
-        - confirm_password
-      properties:
-        current_password:
-          type: string
-        new_password:
-          type: string
-        confirm_password:
-          type: string
-    MessageResponse:
+      - budget_file
+      - created_at
+      - current_balance
+      - id
+      - name
+      - updated_at
+    AccountTypeEnum:
+      enum:
+      - checking
+      - savings
+      - cash
+      - credit
+      - asset
+      - liability
+      type: string
+      description: |-
+        * `checking` - Checking
+        * `savings` - Savings
+        * `cash` - Cash
+        * `credit` - Credit Card
+        * `asset` - Asset
+        * `liability` - Liability
+    Budget:
       type: object
       properties:
-        message:
+        id:
+          type: integer
+          readOnly: true
+        month:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        year:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        amount_limit:
           type: string
-        error:
+          format: decimal
+          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
+        user:
+          type: integer
+          readOnly: true
+        category:
+          type: integer
+      required:
+      - amount_limit
+      - category
+      - id
+      - month
+      - user
+      - year
+    BudgetFile:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
           type: string
+          maxLength: 120
+        currency_code:
+          type: string
+          maxLength: 3
+        is_default:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - updated_at
+    BudgetMonth:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        year:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        month:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        mode:
+          $ref: '#/components/schemas/ModeEnum'
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - month
+      - updated_at
+      - year
     Category:
       type: object
-      required:
-        - id
-        - name
-        - type
       properties:
         id:
           type: integer
+          readOnly: true
         name:
           type: string
+          maxLength: 100
         type:
-          $ref: '#/components/schemas/TypeEnum'
+          $ref: '#/components/schemas/TypeF1eEnum'
         user:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - id
+      - name
+      - type
+      - user
+    CategoryGroupV2:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - name
+      - updated_at
+    CategoryV2:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        group:
           type: integer
           nullable: true
-    CategoryRequest:
-      type: object
-      required:
-        - name
-        - type
-      properties:
         name:
           type: string
-        type:
-          $ref: '#/components/schemas/TypeEnum'
-    Transaction:
-      type: object
+          maxLength: 120
+        kind:
+          $ref: '#/components/schemas/KindEnum'
+        is_archived:
+          type: boolean
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
       required:
-        - id
-        - user
-        - title
-        - amount
-        - type
-        - transaction_date
+      - budget_file
+      - created_at
+      - id
+      - name
+      - updated_at
+    DepartmentEnum:
+      enum:
+      - engineering
+      - finance
+      - hr
+      - marketing
+      - sales
+      - other
+      type: string
+      description: |-
+        * `engineering` - Engineering
+        * `finance` - Finance
+        * `hr` - HR
+        * `marketing` - Marketing
+        * `sales` - Sales
+        * `other` - Other
+    EncryptedBackupBundle:
+      type: object
       properties:
         id:
           type: integer
-        user:
-          type: integer
-        title:
+          readOnly: true
+        bundle_id:
           type: string
+          format: uuid
+          readOnly: true
+        budget_file:
+          type: integer
+        encryption_algorithm:
+          type: string
+          maxLength: 32
+        key_derivation:
+          type: string
+          maxLength: 32
+        salt:
+          type: string
+        nonce:
+          type: string
+        ciphertext:
+          type: string
+        metadata: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - bundle_id
+      - ciphertext
+      - created_at
+      - id
+      - nonce
+      - salt
+    EnvelopeAssignment:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_month:
+          type: integer
+        category:
+          type: integer
+        assigned_amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        carryover_amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        goal_type:
+          $ref: '#/components/schemas/GoalTypeEnum'
+        goal_value:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+          nullable: true
+        goal_date:
+          type: string
+          format: date
+          nullable: true
+        goal_schedule:
+          type: string
+          maxLength: 200
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_month
+      - category
+      - created_at
+      - id
+      - updated_at
+    ExportJob:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        format:
+          $ref: '#/components/schemas/ExportJobFormatEnum'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/ExportJobStatusEnum'
+          readOnly: true
+        filters: {}
+        file_name:
+          type: string
+          readOnly: true
+        error_message:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        completed_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+      required:
+      - budget_file
+      - completed_at
+      - created_at
+      - error_message
+      - file_name
+      - format
+      - id
+      - status
+      - updated_at
+    ExportJobFormatEnum:
+      enum:
+      - csv
+      - json
+      - xlsx
+      type: string
+      description: |-
+        * `csv` - CSV
+        * `json` - JSON
+        * `xlsx` - XLSX
+    ExportJobStatusEnum:
+      enum:
+      - pending
+      - running
+      - completed
+      - failed
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `running` - Running
+        * `completed` - Completed
+        * `failed` - Failed
+    FrequencyEnum:
+      enum:
+      - daily
+      - weekly
+      - monthly
+      - yearly
+      - custom
+      type: string
+      description: |-
+        * `daily` - Daily
+        * `weekly` - Weekly
+        * `monthly` - Monthly
+        * `yearly` - Yearly
+        * `custom` - Custom
+    GoalTypeEnum:
+      enum:
+      - none
+      - target_balance
+      - monthly_contribution
+      - percent_income
+      - remainder
+      - by_date
+      - by_schedule
+      type: string
+      description: |-
+        * `none` - None
+        * `target_balance` - Target Balance
+        * `monthly_contribution` - Monthly Contribution
+        * `percent_income` - Percent Income
+        * `remainder` - Remainder
+        * `by_date` - By Date
+        * `by_schedule` - By Schedule
+    ImportJob:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        format:
+          $ref: '#/components/schemas/ImportJobFormatEnum'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/ImportJobStatusEnum'
+          readOnly: true
+        source_filename:
+          type: string
+          maxLength: 255
+        source_payload:
+          type: string
+        preview_summary:
+          readOnly: true
+        mapping: {}
+        error_message:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - error_message
+      - format
+      - id
+      - preview_summary
+      - status
+      - updated_at
+    ImportJobFormatEnum:
+      enum:
+      - csv
+      - ofx
+      - qfx
+      - qif
+      - camt053
+      - ynab4
+      - nynab
+      type: string
+      description: |-
+        * `csv` - CSV
+        * `ofx` - OFX
+        * `qfx` - QFX
+        * `qif` - QIF
+        * `camt053` - CAMT.053
+        * `ynab4` - YNAB4
+        * `nynab` - nYNAB
+    ImportJobStatusEnum:
+      enum:
+      - uploaded
+      - previewed
+      - importing
+      - completed
+      - failed
+      type: string
+      description: |-
+        * `uploaded` - Uploaded
+        * `previewed` - Previewed
+        * `importing` - Importing
+        * `completed` - Completed
+        * `failed` - Failed
+    KindEnum:
+      enum:
+      - income
+      - expense
+      type: string
+      description: |-
+        * `income` - Income
+        * `expense` - Expense
+    LedgerPostingRead:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        account:
+          type: integer
+          nullable: true
+        account_name:
+          type: string
+          readOnly: true
+        category:
+          type: integer
+          nullable: true
+        category_name:
+          type: string
+          readOnly: true
         amount:
           type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        memo:
+          type: string
+          maxLength: 255
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+      required:
+      - account_name
+      - amount
+      - category_name
+      - id
+    LedgerPostingWrite:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        account:
+          type: integer
+          nullable: true
+        category:
+          type: integer
+          nullable: true
+        amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        memo:
+          type: string
+          maxLength: 255
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+      required:
+      - amount
+      - id
+    LedgerTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        transaction_date:
+          type: string
+          format: date
+        payee:
+          type: integer
+          nullable: true
+        memo:
+          type: string
+        source_type:
+          $ref: '#/components/schemas/SourceTypeEnum'
+        cleared:
+          type: boolean
+        imported:
+          type: boolean
+        match_key:
+          type: string
+          maxLength: 255
+        transfer_group:
+          type: string
+          format: uuid
+          nullable: true
+        postings:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerPostingWrite'
+          writeOnly: true
+        posting_lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerPostingRead'
+          readOnly: true
+        tags:
+          type: array
+          items:
+            type: integer
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - posting_lines
+      - postings
+      - transaction_date
+      - updated_at
+    ModeEnum:
+      enum:
+      - envelope
+      - traditional
+      type: string
+      description: |-
+        * `envelope` - Envelope
+        * `traditional` - Traditional
+    PaginatedBudgetList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Budget'
+    PaginatedCategoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+    PaginatedTransactionList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Transaction'
+    PatchedAccount:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        type:
+          $ref: '#/components/schemas/AccountTypeEnum'
+        opening_balance:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        current_balance:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+          readOnly: true
+        is_archived:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedBudget:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        month:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        year:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        amount_limit:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
+        user:
+          type: integer
+          readOnly: true
+        category:
+          type: integer
+    PatchedBudgetFile:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        currency_code:
+          type: string
+          maxLength: 3
+        is_default:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedBudgetMonth:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        year:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        month:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        mode:
+          $ref: '#/components/schemas/ModeEnum'
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        type:
+          $ref: '#/components/schemas/TypeF1eEnum'
+        user:
+          type: integer
+          readOnly: true
+          nullable: true
+    PatchedCategoryGroupV2:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedCategoryV2:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        group:
+          type: integer
+          nullable: true
+        name:
+          type: string
+          maxLength: 120
+        kind:
+          $ref: '#/components/schemas/KindEnum'
+        is_archived:
+          type: boolean
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedEncryptedBackupBundle:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        bundle_id:
+          type: string
+          format: uuid
+          readOnly: true
+        budget_file:
+          type: integer
+        encryption_algorithm:
+          type: string
+          maxLength: 32
+        key_derivation:
+          type: string
+          maxLength: 32
+        salt:
+          type: string
+        nonce:
+          type: string
+        ciphertext:
+          type: string
+        metadata: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedEnvelopeAssignment:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_month:
+          type: integer
+        category:
+          type: integer
+        assigned_amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        carryover_amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+        goal_type:
+          $ref: '#/components/schemas/GoalTypeEnum'
+        goal_value:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,12}(?:\.\d{0,2})?$
+          nullable: true
+        goal_date:
+          type: string
+          format: date
+          nullable: true
+        goal_schedule:
+          type: string
+          maxLength: 200
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        notes_md:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedExportJob:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        format:
+          $ref: '#/components/schemas/ExportJobFormatEnum'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/ExportJobStatusEnum'
+          readOnly: true
+        filters: {}
+        file_name:
+          type: string
+          readOnly: true
+        error_message:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        completed_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+    PatchedImportJob:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        format:
+          $ref: '#/components/schemas/ImportJobFormatEnum'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/ImportJobStatusEnum'
+          readOnly: true
+        source_filename:
+          type: string
+          maxLength: 255
+        source_payload:
+          type: string
+        preview_summary:
+          readOnly: true
+        mapping: {}
+        error_message:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedLedgerTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        transaction_date:
+          type: string
+          format: date
+        payee:
+          type: integer
+          nullable: true
+        memo:
+          type: string
+        source_type:
+          $ref: '#/components/schemas/SourceTypeEnum'
+        cleared:
+          type: boolean
+        imported:
+          type: boolean
+        match_key:
+          type: string
+          maxLength: 255
+        transfer_group:
+          type: string
+          format: uuid
+          nullable: true
+        postings:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerPostingWrite'
+          writeOnly: true
+        posting_lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerPostingRead'
+          readOnly: true
+        tags:
+          type: array
+          items:
+            type: integer
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedPayee:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedSavedReport:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 160
+        report_type:
+          $ref: '#/components/schemas/ReportTypeEnum'
+        definition: {}
+        pinned:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedScheduledTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        is_active:
+          type: boolean
+        start_date:
+          type: string
+          format: date
+        next_run_date:
+          type: string
+          format: date
+        frequency:
+          $ref: '#/components/schemas/FrequencyEnum'
+        interval:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        transaction_template: {}
+        last_run_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedTag:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 80
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        user:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        amount:
+          type: string
+          format: decimal
           pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
         type:
-          $ref: '#/components/schemas/TypeEnum'
+          $ref: '#/components/schemas/TypeF1eEnum'
         category:
           type: integer
           nullable: true
@@ -698,133 +4889,417 @@ components:
         created_at:
           type: string
           format: date-time
+          readOnly: true
         updated_at:
           type: string
           format: date-time
-    TransactionRequest:
+          readOnly: true
+    PatchedTransactionRule:
       type: object
-      required:
-        - title
-        - amount
-        - type
-        - transaction_date
       properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        is_active:
+          type: boolean
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        conditions: {}
+        actions: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    PatchedUserProfile:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        phone_number:
+          type: string
+          maxLength: 20
+        location:
+          type: string
+          maxLength: 100
+        bio:
+          type: string
+        department:
+          $ref: '#/components/schemas/DepartmentEnum'
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          readOnly: true
+    Payee:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - name
+      - updated_at
+    ReportTypeEnum:
+      enum:
+      - net_worth
+      - cash_flow
+      - spending
+      - custom
+      type: string
+      description: |-
+        * `net_worth` - Net Worth
+        * `cash_flow` - Cash Flow
+        * `spending` - Spending Trends
+        * `custom` - Custom
+    RoleEnum:
+      enum:
+      - admin
+      - manager
+      - employee
+      type: string
+      description: |-
+        * `admin` - Admin
+        * `manager` - Manager
+        * `employee` - Employee
+    SavedReport:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 160
+        report_type:
+          $ref: '#/components/schemas/ReportTypeEnum'
+        definition: {}
+        pinned:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - name
+      - report_type
+      - updated_at
+    ScheduledTransaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 120
+        is_active:
+          type: boolean
+        start_date:
+          type: string
+          format: date
+        next_run_date:
+          type: string
+          format: date
+        frequency:
+          $ref: '#/components/schemas/FrequencyEnum'
+        interval:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        transaction_template: {}
+        last_run_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - last_run_at
+      - name
+      - next_run_date
+      - start_date
+      - updated_at
+    SourceTypeEnum:
+      enum:
+      - manual
+      - import
+      - rule
+      - scheduled
+      - transfer
+      type: string
+      description: |-
+        * `manual` - Manual
+        * `import` - Import
+        * `rule` - Rule
+        * `scheduled` - Scheduled
+        * `transfer` - Transfer
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        budget_file:
+          type: integer
+        name:
+          type: string
+          maxLength: 80
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - budget_file
+      - created_at
+      - id
+      - name
+      - updated_at
+    TokenObtainPair:
+      type: object
+      properties:
+        email:
+          type: string
+          writeOnly: true
+        password:
+          type: string
+          writeOnly: true
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+          readOnly: true
+      required:
+      - access
+      - email
+      - password
+      - refresh
+    TokenRefresh:
+      type: object
+      properties:
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+      required:
+      - access
+      - refresh
+    Transaction:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
         user:
           type: integer
+          readOnly: true
         title:
           type: string
+          maxLength: 255
         amount:
           type: string
+          format: decimal
           pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
         type:
-          $ref: '#/components/schemas/TypeEnum'
+          $ref: '#/components/schemas/TypeF1eEnum'
         category:
           type: integer
           nullable: true
         transaction_date:
           type: string
           format: date
-    Budget:
-      type: object
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
       required:
-        - id
-        - user
-        - category
-        - month
-        - year
-        - amount_limit
+      - amount
+      - created_at
+      - id
+      - title
+      - transaction_date
+      - type
+      - updated_at
+      - user
+    TransactionRule:
+      type: object
       properties:
         id:
           type: integer
-        user:
+          readOnly: true
+        budget_file:
           type: integer
-        category:
-          type: integer
-        month:
-          type: integer
-          minimum: 1
-          maximum: 12
-        year:
-          type: integer
-        amount_limit:
+        name:
           type: string
-          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
-    BudgetRequest:
-      type: object
+          maxLength: 120
+        is_active:
+          type: boolean
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        conditions: {}
+        actions: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
       required:
-        - category
-        - month
-        - year
-        - amount_limit
-      properties:
-        category:
-          type: integer
-        month:
-          type: integer
-          minimum: 1
-          maximum: 12
-        year:
-          type: integer
-        amount_limit:
-          type: string
-          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
-    PaginatedCategoryList:
+      - budget_file
+      - created_at
+      - id
+      - name
+      - updated_at
+    TypeF1eEnum:
+      enum:
+      - income
+      - expense
+      type: string
+      description: |-
+        * `income` - Income
+        * `expense` - Expense
+    UserProfile:
       type: object
-      required:
-        - count
-        - next
-        - previous
-        - results
       properties:
-        count:
+        id:
           type: integer
-        next:
+          readOnly: true
+        email:
           type: string
-          nullable: true
-        previous:
+          format: email
+          readOnly: true
+        first_name:
           type: string
-          nullable: true
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/Category'
-    PaginatedTransactionList:
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        phone_number:
+          type: string
+          maxLength: 20
+        location:
+          type: string
+          maxLength: 100
+        bio:
+          type: string
+        department:
+          $ref: '#/components/schemas/DepartmentEnum'
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          readOnly: true
+      required:
+      - email
+      - id
+      - role
+    UserRegistration:
       type: object
-      required:
-        - count
-        - next
-        - previous
-        - results
       properties:
-        count:
-          type: integer
-        next:
+        email:
           type: string
-          nullable: true
-        previous:
+          format: email
+          maxLength: 254
+        username:
           type: string
-          nullable: true
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/Transaction'
-    PaginatedBudgetList:
-      type: object
+        password:
+          type: string
+          writeOnly: true
+        confirm_password:
+          type: string
+          writeOnly: true
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        phone_number:
+          type: string
+          maxLength: 20
+        location:
+          type: string
+          maxLength: 100
+        bio:
+          type: string
+        department:
+          $ref: '#/components/schemas/DepartmentEnum'
       required:
-        - count
-        - next
-        - previous
-        - results
-      properties:
-        count:
-          type: integer
-        next:
-          type: string
-          nullable: true
-        previous:
-          type: string
-          nullable: true
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/Budget'
+      - confirm_password
+      - email
+      - password
+  securitySchemes:
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
**PR 7 of a stack**, based on #12.

## The schema described a different API than the one that exists

`web/schema/pft.yaml` documented **only the 12 legacy paths**. The entire finance domain — 16 resources, the double-entry ledger, envelope budgeting, reports, imports, exports, backups, 1051 lines of `finance_services.py` — was absent. That is the API the UI actually calls, so Swagger showed a fraction of the surface and any codegen was working from a fiction.

Regenerated with drf-spectacular from the backend: **61 paths, 48 of them under `/api/v1/finance/`**.

## The audit script was wrong in both directions

`scripts/feature_audit.py` scrapes source with regexes. Three separate defects:

1. `router.register()` calls that **wrap across lines** were missed — `scheduled-transactions` looked absent from the backend.
2. **`@action` routes were never parsed**, so all 16 custom endpoints (`run-due`, `bulk-update`, `balances`, `snapshot`, `download`, `preview`, `execute`, …) looked like schema entries with nothing behind them.
3. **`include()` mounts were counted as endpoints**, so `/api/v1/finance/` itself was reported as missing from the schema.

Together with the missing `finance_routers.py` (fixed in #12), this is why the report claimed `Gate status: PASS` and `Active Backend Endpoints Missing From Schema: None` while the real answer was 31.

All three fixed. Backend and schema now agree at **61 endpoints each**, with 16 action routes correctly detected:

```
backend endpoints: 61
schema endpoints : 61
action routes detected: 16
```

The "no parity findings" result is now earned rather than an artefact of not looking.

## ARCHITECTURE.md

Explains what the code does not say for itself:

- **Why two API surfaces coexist**, what each is for, and that new work belongs in the finance domain
- The double-entry invariant (postings sum to zero), and that the exactly-one-target rule is a **database** constraint while the zero-sum rule is only enforced in the serializer
- That **`UserScopedModelViewSet` does not scope anything** despite its name — every viewset filters its own queryset, and `LedgerPosting`, `EnvelopeAssignment` and `TransactionEvent` have no user column at all
- That filtering the queryset is not sufficient: **any id accepted from the request body must be ownership-checked**. Every isolation bug this project has had was that shape.

## docs/self-hosting.md

What the README deliberately leaves out: reverse proxy and TLS (Caddy and nginx), rate limiting `/admin/` at the edge, creating an account now that no default admin exists, `pg_dump`/restore, upgrades, `prune_finance_jobs` housekeeping, `/healthz/` monitoring, and the failure modes people actually hit (redirect loops from a missing `X-Forwarded-Proto`, `DisallowedHost`, everyone signed out after a restart).

## Also

Corrects the known-limitations lists in README and SECURITY.md. Throttling and token revocation landed in #9, so still claiming they're missing is as misleading as the reverse was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)