### PR TITLE
feat(account): implement account deletion

### DIFF
--- a/api/pft/tests/test_account_deletion.py
+++ b/api/pft/tests/test_account_deletion.py
@@ -1,0 +1,111 @@
+"""Account deletion.
+
+The settings page had a permanently disabled "Delete Account" button and there
+was no endpoint behind it, so there was no way to get your data out of a
+FinTrack instance short of dropping the database.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from pft.models import BudgetFile, LedgerTransaction, Transaction
+
+User = get_user_model()
+
+PASSWORD = "StrongPass123!"
+URL = "/api/v1/profile/delete-account/"
+
+
+class DeleteAccountTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+        self.email = "leaving@example.com"
+        self.user = User.objects.create_user(
+            email=self.email, username=self.email, password=PASSWORD
+        )
+        self.other = User.objects.create_user(
+            email="staying@example.com",
+            username="staying@example.com",
+            password=PASSWORD,
+        )
+
+        self.transaction = Transaction.objects.create(
+            user=self.user,
+            title="Coffee",
+            amount="4.50",
+            type="expense",
+            transaction_date=date(2026, 3, 10),
+        )
+        self.budget_file = BudgetFile.objects.get(user=self.user, is_default=True)
+        self.ledger_transaction = LedgerTransaction.objects.create(
+            budget_file=self.budget_file,
+            transaction_date=date(2026, 3, 10),
+            memo="Coffee",
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.post(URL, {"password": PASSWORD}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_requires_a_password(self):
+        response = self.client.post(URL, {"confirmation": "DELETE"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
+    def test_rejects_a_wrong_password(self):
+        response = self.client.post(
+            URL, {"password": "not-my-password", "confirmation": "DELETE"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
+    def test_requires_the_confirmation_phrase(self):
+        response = self.client.post(
+            URL, {"password": PASSWORD, "confirmation": "yes"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
+    def test_deletes_the_account_and_all_of_its_data(self):
+        response = self.client.post(
+            URL, {"password": PASSWORD, "confirmation": "DELETE"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
+        self.assertFalse(Transaction.objects.filter(pk=self.transaction.pk).exists())
+        self.assertFalse(BudgetFile.objects.filter(pk=self.budget_file.pk).exists())
+        self.assertFalse(
+            LedgerTransaction.objects.filter(pk=self.ledger_transaction.pk).exists()
+        )
+
+    def test_leaves_other_accounts_untouched(self):
+        other_budget_file = BudgetFile.objects.get(user=self.other, is_default=True)
+
+        self.client.post(
+            URL, {"password": PASSWORD, "confirmation": "DELETE"}, format="json"
+        )
+
+        self.assertTrue(User.objects.filter(pk=self.other.pk).exists())
+        self.assertTrue(BudgetFile.objects.filter(pk=other_budget_file.pk).exists())
+
+    def test_tokens_stop_working_after_deletion(self):
+        tokens = self.client.post(
+            "/api/token/", {"email": self.email, "password": PASSWORD}, format="json"
+        )
+        refresh = tokens.data["refresh"]
+
+        self.client.post(URL, {"password": PASSWORD, "confirmation": "DELETE"}, format="json")
+
+        self.client.force_authenticate(user=None)
+        response = self.client.post("/api/token/refresh/", {"refresh": refresh}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/api/pft/urls.py
+++ b/api/pft/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from .routers import router
 from .views import (
     ChangePasswordView,
+    DeleteAccountView,
     MeView,
     RegisterUserAPIView,
     UpdateProfileView,
@@ -16,4 +17,5 @@ urlpatterns = [
     path("me/", MeView.as_view(), name="me"),
     path("profile/update/", UpdateProfileView.as_view(), name="update-profile"),
     path("profile/change-password/", ChangePasswordView.as_view(), name="change-password"),
+    path("profile/delete-account/", DeleteAccountView.as_view(), name="delete-account"),
 ]

--- a/api/pft/views.py
+++ b/api/pft/views.py
@@ -234,6 +234,51 @@ class UpdateProfileView(generics.UpdateAPIView):
         return self.request.user
 
 
+class DeleteAccountView(APIView):
+    """Permanently delete the caller's account and everything it owns.
+
+    Requires the current password and an explicit confirmation string, because
+    the cascade takes every budget file, account, transaction and posting with
+    it and there is no undo.
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "password_change"
+
+    CONFIRMATION = "DELETE"
+
+    def post(self, request):
+        user = request.user
+        password = request.data.get("password")
+        confirmation = request.data.get("confirmation")
+
+        if not password:
+            return Response(
+                {"error": "Your password is required to delete your account."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not user.check_password(password):
+            return Response(
+                {"error": "Password is incorrect"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if confirmation != self.CONFIRMATION:
+            return Response(
+                {"error": f"Type {self.CONFIRMATION} to confirm."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Revoke sessions before the rows disappear, so no token outlives the
+        # account it belonged to.
+        blacklist_all_refresh_tokens(user)
+        user.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 class ChangePasswordView(APIView):
     permission_classes = [IsAuthenticated]
     throttle_classes = [ScopedRateThrottle]

--- a/web/app/components/delete-account-dialog.tsx
+++ b/web/app/components/delete-account-dialog.tsx
@@ -1,0 +1,114 @@
+import { httpPFTClient } from '@/client/httpPFTClient'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { logout } from '@/lib/auth'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+const CONFIRMATION = 'DELETE'
+
+/**
+ * Deleting an account cascades to every budget file, account, transaction and
+ * posting the user owns, and there is no undo. The dialog therefore asks for
+ * the password and an explicit confirmation phrase, and the API checks both.
+ */
+export function DeleteAccountDialog() {
+  const [open, setOpen] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirmation, setConfirmation] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const canSubmit = password.length > 0 && confirmation === CONFIRMATION && !submitting
+
+  const reset = () => {
+    setPassword('')
+    setConfirmation('')
+  }
+
+  const deleteAccount = async () => {
+    setSubmitting(true)
+    try {
+      await httpPFTClient({
+        url: '/api/v1/profile/delete-account/',
+        method: 'POST',
+        data: { password, confirmation },
+      })
+      toast.success('Your account and all of its data have been deleted.')
+      // logout() clears the local tokens and redirects to /login. The refresh
+      // token is already revoked server-side by the delete endpoint.
+      await logout()
+    } catch (error: unknown) {
+      const message =
+        (error as { errorMessage?: string })?.errorMessage ??
+        'Could not delete the account. Check your password and try again.'
+      toast.error(message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant='destructive'>Delete Account</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete your account?</DialogTitle>
+          <DialogDescription>
+            This permanently deletes your account and everything in it: every budget file,
+            account, category, transaction and report. It cannot be undone. Export your data
+            first if you want to keep it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          <div className='space-y-2'>
+            <Label htmlFor='delete-account-password'>Confirm your password</Label>
+            <Input
+              id='delete-account-password'
+              type='password'
+              autoComplete='current-password'
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='delete-account-confirmation'>
+              Type <span className='font-mono font-semibold'>{CONFIRMATION}</span> to confirm
+            </Label>
+            <Input
+              id='delete-account-confirmation'
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant='outline' onClick={() => setOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button variant='destructive' onClick={deleteAccount} disabled={!canSubmit}>
+            {submitting ? 'Deleting...' : 'Delete my account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/app/pages/settings/index.tsx
+++ b/web/app/pages/settings/index.tsx
@@ -1,4 +1,5 @@
 import { httpPFTClient } from '@/client/httpPFTClient'
+import { DeleteAccountDialog } from '@/components/delete-account-dialog'
 import { AnimateSpinner } from '@/components/spinner'
 import { Button } from '@/components/ui/button'
 import {
@@ -385,9 +386,7 @@ export default function UserSettingsPage() {
                       Permanently delete your account and all data
                     </p>
                   </div>
-                  <Button variant='destructive' disabled>
-                    Delete Account
-                  </Button>
+                  <DeleteAccountDialog />
                 </div>
               </CardContent>
             </Card>

--- a/web/schema/pft.yaml
+++ b/web/schema/pft.yaml
@@ -3454,6 +3454,22 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/v1/profile/delete-account/:
+    post:
+      operationId: v1_profile_delete_account_create
+      description: |-
+        Permanently delete the caller's account and everything it owns.
+
+        Requires the current password and an explicit confirmation string, because
+        the cascade takes every budget file, account, transaction and posting with
+        it and there is no undo.
+      tags:
+      - v1
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/v1/profile/update/:
     put:
       operationId: v1_profile_update_update


### PR DESCRIPTION
**PR 8 of a stack**, based on #13.

## Why

The settings page shipped a **permanently disabled** "Delete Account" button with **no endpoint behind it**. The feature audit has it as `Partial`/`AtRisk`. For a product whose pitch is "your data, your server", not being able to remove your data is a conspicuous gap — the only option was dropping the database.

## API

`POST /api/v1/profile/delete-account/`

```json
{ "password": "...", "confirmation": "DELETE" }
```

- Requires the **current password** and the literal string `DELETE`. Both are checked server-side, not just in the dialog.
- **Revokes every outstanding refresh token before deleting the user**, so no token outlives the account it belonged to.
- The cascade removes the budget files, accounts, categories, transactions, postings, reports and jobs the user owns.
- Throttled on the same scope as password changes.
- Returns `204 No Content`.

## UI

The disabled button becomes a dialog that says plainly what is about to happen, asks for the password and the confirmation phrase, and signs the user out afterwards. The submit button stays disabled until both fields are valid.

## Tests

Seven cases covering every refusal path and the destructive path:

- unauthenticated → 401
- missing password → 400, user still exists
- wrong password → 400, user still exists
- wrong confirmation phrase → 400, user still exists
- success → 204, and the user, their legacy transactions, budget file and ledger transactions are all gone
- **another user's budget file is untouched**
- a refresh token obtained before deletion no longer works

56 backend tests pass, `ruff check` clean, web lint and build clean. The OpenAPI schema is regenerated (62 paths) and the parity report still reports zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)