### PR TITLE
fix(web): make currency real and move transaction filtering to the server

### DIFF
--- a/api/pft/finance_views.py
+++ b/api/pft/finance_views.py
@@ -1,10 +1,14 @@
 from datetime import date
+from decimal import Decimal
 
+from django.db.models import Q, Sum, Value
+from django.db.models.functions import Abs, Coalesce
 from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from .finance_serializers import (
@@ -175,11 +179,20 @@ class TagViewSet(UserScopedModelViewSet):
         return queryset
 
 
+class LedgerTransactionPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = 500
+
+
 class LedgerTransactionViewSet(UserScopedModelViewSet):
     serializer_class = LedgerTransactionSerializer
+    pagination_class = LedgerTransactionPagination
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ["memo", "payee__name", "match_key"]
-    ordering_fields = ["transaction_date", "created_at", "updated_at", "id"]
+    # `amount` is annotated below: a ledger transaction has no amount column,
+    # the figure people mean lives on its category posting.
+    ordering_fields = ["transaction_date", "created_at", "updated_at", "id", "amount"]
     ordering = ["-transaction_date", "-id"]
 
     def get_queryset(self):
@@ -187,17 +200,35 @@ class LedgerTransactionViewSet(UserScopedModelViewSet):
             LedgerTransaction.objects.filter(budget_file__user=self.request.user)
             .select_related("payee")
             .prefetch_related("postings__account", "postings__category", "tags")
+            .annotate(
+                amount=Abs(
+                    Coalesce(
+                        Sum(
+                            "postings__amount",
+                            filter=Q(postings__category__isnull=False),
+                        ),
+                        Value(Decimal("0.00")),
+                    )
+                )
+            )
             .order_by("-transaction_date", "-id")
         )
         budget_file = self.request.query_params.get("budget_file")
         if budget_file:
             queryset = queryset.filter(budget_file_id=budget_file)
-        start_date = self.request.query_params.get("start_date")
+        start_date = parse_iso_date(self.request.query_params.get("start_date"), "start_date")
         if start_date:
             queryset = queryset.filter(transaction_date__gte=start_date)
-        end_date = self.request.query_params.get("end_date")
+        end_date = parse_iso_date(self.request.query_params.get("end_date"), "end_date")
         if end_date:
             queryset = queryset.filter(transaction_date__lte=end_date)
+
+        # Income and expense are a property of the category on the posting, not
+        # of the transaction, so filtering by "type" filters on that category.
+        tx_type = self.request.query_params.get("type")
+        if tx_type in {CategoryV2.KIND_INCOME, CategoryV2.KIND_EXPENSE}:
+            queryset = queryset.filter(postings__category__kind=tx_type).distinct()
+
         return queryset
 
     @action(detail=False, methods=["post"], url_path="bulk-update")

--- a/api/pft/tests/test_ledger_filtering.py
+++ b/api/pft/tests/test_ledger_filtering.py
@@ -1,0 +1,131 @@
+"""Server-side filtering, ordering and pagination for the ledger.
+
+The transactions page used to filter and sort in the browser over whatever page
+happened to be loaded, so the result count disagreed with the rows on screen and
+"highest amount" only meant highest on this page.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from pft.models import (
+    Account,
+    BudgetFile,
+    CategoryV2,
+    LedgerPosting,
+    LedgerTransaction,
+)
+
+User = get_user_model()
+
+URL = "/api/v1/finance/transactions/"
+
+
+class LedgerFilteringTests(APITestCase):
+    def setUp(self):
+        email = "ledger@example.com"
+        self.user = User.objects.create_user(
+            email=email, username=email, password="StrongPass123!"
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.budget_file = BudgetFile.objects.get(user=self.user, is_default=True)
+        self.account = Account.objects.get(budget_file=self.budget_file, name="Cash")
+        self.expense_category = CategoryV2.objects.filter(
+            budget_file=self.budget_file, kind=CategoryV2.KIND_EXPENSE
+        ).first()
+        self.income_category = CategoryV2.objects.filter(
+            budget_file=self.budget_file, kind=CategoryV2.KIND_INCOME
+        ).first()
+
+        self.small_expense = self.make_transaction(
+            "Coffee", Decimal("5.00"), date(2026, 1, 5), income=False
+        )
+        self.large_expense = self.make_transaction(
+            "Rent", Decimal("1200.00"), date(2026, 2, 1), income=False
+        )
+        self.salary = self.make_transaction(
+            "Salary", Decimal("4200.00"), date(2026, 3, 1), income=True
+        )
+
+    def make_transaction(self, memo, amount, when, *, income):
+        ledger_tx = LedgerTransaction.objects.create(
+            budget_file=self.budget_file, transaction_date=when, memo=memo
+        )
+        account_amount = amount if income else -amount
+        LedgerPosting.objects.create(
+            transaction=ledger_tx, account=self.account, amount=account_amount, sort_order=0
+        )
+        LedgerPosting.objects.create(
+            transaction=ledger_tx,
+            category=self.income_category if income else self.expense_category,
+            amount=-account_amount,
+            sort_order=1,
+        )
+        return ledger_tx
+
+    def ids(self, response):
+        return [row["id"] for row in response.data["results"]]
+
+    def test_list_is_paginated(self):
+        response = self.client.get(URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+        self.assertIn("results", response.data)
+
+    def test_page_size_is_capped(self):
+        response = self.client.get(f"{URL}?page_size=100000")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertLessEqual(len(response.data["results"]), 500)
+
+    def test_filter_by_type_expense(self):
+        response = self.client.get(f"{URL}?type=expense")
+        self.assertEqual(response.data["count"], 2)
+        self.assertNotIn(self.salary.id, self.ids(response))
+
+    def test_filter_by_type_income(self):
+        response = self.client.get(f"{URL}?type=income")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(self.ids(response), [self.salary.id])
+
+    def test_search_matches_the_memo(self):
+        response = self.client.get(f"{URL}?search=Rent")
+        self.assertEqual(self.ids(response), [self.large_expense.id])
+
+    def test_filter_by_date_range(self):
+        response = self.client.get(f"{URL}?start_date=2026-02-01&end_date=2026-02-28")
+        self.assertEqual(self.ids(response), [self.large_expense.id])
+
+    def test_order_by_amount_uses_the_displayed_magnitude(self):
+        """Income postings are negative on the category side; ordering must not
+        be fooled by the sign, because the UI shows absolute amounts."""
+        ascending = self.client.get(f"{URL}?ordering=amount")
+        self.assertEqual(
+            self.ids(ascending),
+            [self.small_expense.id, self.large_expense.id, self.salary.id],
+        )
+
+        descending = self.client.get(f"{URL}?ordering=-amount")
+        self.assertEqual(
+            self.ids(descending),
+            [self.salary.id, self.large_expense.id, self.small_expense.id],
+        )
+
+    def test_order_by_date(self):
+        response = self.client.get(f"{URL}?ordering=transaction_date")
+        self.assertEqual(
+            self.ids(response),
+            [self.small_expense.id, self.large_expense.id, self.salary.id],
+        )
+
+    def test_filters_combine(self):
+        response = self.client.get(f"{URL}?type=expense&ordering=-amount")
+        self.assertEqual(self.ids(response), [self.large_expense.id, self.small_expense.id])
+
+    def test_malformed_date_is_a_400(self):
+        response = self.client.get(f"{URL}?start_date=not-a-date")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/web/app/client/pft/v1/v1.ts
+++ b/web/app/client/pft/v1/v1.ts
@@ -1,4 +1,5 @@
 import { httpPFTClient } from '@/client/httpPFTClient'
+import { getDefaultBudgetFileId } from '@/lib/finance-client'
 import type { SWRConfiguration } from 'swr'
 import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
@@ -34,6 +35,8 @@ export interface V1TransactionsListParams {
   search?: string
   start_date?: string
   end_date?: string
+  /** 'income' | 'expense'; filters on the category kind of the posting. */
+  type?: string
 }
 
 export interface V1CategoryListParams {
@@ -67,11 +70,6 @@ export interface BudgetMutationPayload {
   month: number
   year: number
   amount_limit: string | number
-}
-
-interface FinanceBudgetFile {
-  id: number
-  is_default: boolean
 }
 
 interface FinanceAccount {
@@ -117,7 +115,6 @@ interface FinanceEnvelopeAssignment {
   assigned_amount: string
 }
 
-let budgetFileCache: number | null = null
 const accountCache: Record<number, number> = {}
 
 const toQueryString = (params: object) => {
@@ -199,24 +196,10 @@ const formatAmount = (value: string | number) => {
 
 const amountAbs = (value: string | number) => Math.abs(Number(value || 0))
 
-const resolveDefaultBudgetFileId = async () => {
-  if (budgetFileCache) return budgetFileCache
-
-  const response = await get<PaginatedResponse<FinanceBudgetFile> | FinanceBudgetFile[]>('/api/v1/finance/budget-files/')
-  const files = asPaginated<FinanceBudgetFile>(response).results
-
-  let selected = files.find((file) => file.is_default) || files[0]
-  if (!selected) {
-    selected = await post<FinanceBudgetFile>('/api/v1/finance/budget-files/', {
-      name: 'Primary Budget',
-      currency_code: 'USD',
-      is_default: true,
-    })
-  }
-
-  budgetFileCache = selected.id
-  return selected.id
-}
+// Delegated to finance-client so there is one budget-file cache rather than two
+// module-level singletons that could disagree, and one place that decides the
+// currency of a newly created budget file.
+const resolveDefaultBudgetFileId = getDefaultBudgetFileId
 
 const resolveDefaultAccountId = async (budgetFileId: number) => {
   if (accountCache[budgetFileId]) return accountCache[budgetFileId]

--- a/web/app/components/overview.tsx
+++ b/web/app/components/overview.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/chart'
 import { EmptyPlaceholder } from '@/components/ui/empty-placeholder'
 import { CircleDollarSign } from 'lucide-react'
-import { useCurrency } from '@/context/currency-context'
+import { formatCurrency, useCurrency } from '@/context/currency-context'
 import { TypeEnum } from '@/client/pft/typeEnum'
 
 interface MonthlyData {
@@ -94,7 +94,7 @@ export function Overview({ transactions }: OverviewProps) {
         />
         <YAxis
           label={{ value: `Amount (${currency.symbol})`, angle: -90, position: 'left' }}
-          tickFormatter={(value) => `${currency.symbol}${value}`}
+          tickFormatter={(value) => formatCurrency(Number(value), currency.code, { maximumFractionDigits: 0 })}
         />
         <ChartTooltip
           cursor={false}
@@ -102,7 +102,7 @@ export function Overview({ transactions }: OverviewProps) {
             <ChartTooltipContent
               active={active}
               payload={payload}
-              formatter={(label, value) => [`${value} - ${currency.symbol}${label}`, ' ']}
+              formatter={(label, value) => [`${value} - ${formatCurrency(Number(label), currency.code)}`, ' ']}
               labelFormatter={() => `Total:`}
             />
           )}
@@ -113,7 +113,7 @@ export function Overview({ transactions }: OverviewProps) {
           radius={[4, 4, 0, 0]}
           label={{
             position: 'top',
-            formatter: (value: number) => `Income ${currency.symbol}${value}`,
+            formatter: (value: number) => `Income ${formatCurrency(value, currency.code)}`,
           }}
           name='Income'
         />
@@ -123,7 +123,7 @@ export function Overview({ transactions }: OverviewProps) {
           radius={[4, 4, 0, 0]}
           label={{
             position: 'top',
-            formatter: (value: number) => `Expenses ${currency.symbol}${value}`,
+            formatter: (value: number) => `Expenses ${formatCurrency(value, currency.code)}`,
           }}
           name='Expenses'
         />

--- a/web/app/components/ui/currency-display.tsx
+++ b/web/app/components/ui/currency-display.tsx
@@ -1,39 +1,39 @@
 'use client'
 
-import { useCurrency } from '@/context/currency-context'
+import { formatCurrency, useCurrency } from '@/context/currency-context'
 import { cn } from '@/lib/utils'
-import { useEffect } from 'react'
 
 interface CurrencyDisplayProps {
   amount: number
   className?: string
   showSymbol?: boolean
-  format?: boolean
+  /** Drop the decimals, for compact axis labels and chart ticks. */
+  compact?: boolean
 }
 
-export function CurrencyDisplay({ 
-  amount, 
-  className, 
+/**
+ * Renders a monetary amount in the active currency.
+ *
+ * Formatting goes through Intl so the symbol, its placement and the digit
+ * grouping follow the currency and the reader's locale. The previous version
+ * hardcoded en-US grouping and prepended the symbol by hand, which rendered
+ * every non-US currency wrong.
+ */
+export function CurrencyDisplay({
+  amount,
+  className,
   showSymbol = true,
-  format = true 
+  compact = false,
 }: CurrencyDisplayProps) {
   const { currency } = useCurrency()
-  
-  useEffect(() => {
-    localStorage.setItem('currency', JSON.stringify(currency))
-  }, [currency])
 
-  const formattedAmount = format 
-    ? new Intl.NumberFormat('en-US', {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }).format(amount)
-    : amount.toString()
+  const options: Intl.NumberFormatOptions = compact
+    ? { maximumFractionDigits: 0 }
+    : { minimumFractionDigits: 2, maximumFractionDigits: 2 }
 
-  return (
-    <span className={cn('whitespace-nowrap', className)}>
-      {showSymbol && <span>{currency.symbol}</span>}
-      {formattedAmount}
-    </span>
-  )
+  const formatted = showSymbol
+    ? formatCurrency(amount, currency.code, options)
+    : new Intl.NumberFormat(undefined, options).format(amount)
+
+  return <span className={cn('whitespace-nowrap', className)}>{formatted}</span>
 }

--- a/web/app/context/currency-context.tsx
+++ b/web/app/context/currency-context.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { getDefaultBudgetFile, updateBudgetFileCurrency } from '@/lib/finance-client'
+import { ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react'
 
-// Currency options with symbols and flags
+// Currency options. `symbol` is only used for compact labels; amounts are
+// formatted by Intl, which knows each currency's real symbol and placement.
 export const currencies = [
   { code: 'INR', symbol: '₹', flag: '🇮🇳', name: 'Indian Rupee' },
   { code: 'USD', symbol: '$', flag: '🇺🇸', name: 'US Dollar' },
@@ -25,6 +27,13 @@ export type Currency = {
   name: string
 }
 
+const STORAGE_KEY = 'currency'
+const DEFAULT_CURRENCY = currencies.find((item) => item.code === 'USD') ?? currencies[0]
+
+export function currencyByCode(code: string | undefined | null): Currency {
+  return currencies.find((item) => item.code === code) ?? DEFAULT_CURRENCY
+}
+
 type CurrencyContextType = {
   currency: Currency
   setCurrency: (currency: Currency) => void
@@ -32,27 +41,48 @@ type CurrencyContextType = {
 
 const CurrencyContext = createContext<CurrencyContextType | undefined>(undefined)
 
+function readStoredCurrency(): Currency {
+  if (typeof window === 'undefined') return DEFAULT_CURRENCY
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (!saved) return DEFAULT_CURRENCY
+  try {
+    return currencyByCode((JSON.parse(saved) as Currency)?.code)
+  } catch {
+    return DEFAULT_CURRENCY
+  }
+}
+
 export function CurrencyProvider({ children }: { children: ReactNode }) {
-  const [currency, setCurrency] = useState<Currency>(() => {
-    if (typeof window !== 'undefined') {
-      const savedCurrency = localStorage.getItem('currency')
-      return savedCurrency ? JSON.parse(savedCurrency) : currencies[0]
-    }
-    return currencies[0]
-  })
+  // localStorage is a cache for first paint. The budget file on the server is
+  // the source of truth: previously the UI defaulted to INR while the client
+  // wrote currency_code: 'USD' when it created the budget file, so the display
+  // and the stored data disagreed.
+  const [currency, setCurrencyState] = useState<Currency>(readStoredCurrency)
 
   useEffect(() => {
-    const handleStorageChange = () => {
-      const savedCurrency = localStorage.getItem('currency')
-      if (savedCurrency) {
-        setCurrency(JSON.parse(savedCurrency))
-      }
-    }
-
-    window.addEventListener('currencyChange', handleStorageChange)
+    let cancelled = false
+    getDefaultBudgetFile()
+      .then((budgetFile) => {
+        if (cancelled || !budgetFile?.currency_code) return
+        const resolved = currencyByCode(budgetFile.currency_code)
+        setCurrencyState(resolved)
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(resolved))
+      })
+      .catch(() => {
+        // Signed out, or the API is unreachable: keep the cached choice.
+      })
     return () => {
-      window.removeEventListener('currencyChange', handleStorageChange)
+      cancelled = true
     }
+  }, [])
+
+  const setCurrency = useCallback((next: Currency) => {
+    setCurrencyState(next)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    // Persist server-side so the choice follows the account, not the browser.
+    updateBudgetFileCurrency(next.code).catch(() => {
+      // Non-fatal: the local display is already updated.
+    })
   }, [])
 
   return (
@@ -68,4 +98,22 @@ export function useCurrency() {
     throw new Error('useCurrency must be used within a CurrencyProvider')
   }
   return context
+}
+
+/** Format an amount in the given currency, using the browser's locale. */
+export function formatCurrency(
+  amount: number,
+  currencyCode: string,
+  options: Intl.NumberFormatOptions = {},
+): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: currencyCode,
+      ...options,
+    }).format(amount)
+  } catch {
+    // Intl throws on an unknown currency code.
+    return `${amount.toFixed(2)} ${currencyCode}`
+  }
 }

--- a/web/app/lib/finance-client.ts
+++ b/web/app/lib/finance-client.ts
@@ -146,9 +146,25 @@ const del = async (url: string): Promise<void> =>
     method: 'DELETE',
   })
 
-let budgetFileCache: number | null = null
+const SUPPORTED_CURRENCY_CODES = new Set([
+  'INR', 'USD', 'EUR', 'GBP', 'JPY', 'CNY', 'CAD', 'AUD', 'CHF', 'KRW', 'SGD', 'HKD',
+])
 
-export const getDefaultBudgetFileId = async () => {
+const LOCALE_CURRENCY: Record<string, string> = {
+  IN: 'INR', US: 'USD', GB: 'GBP', JP: 'JPY', CN: 'CNY', CA: 'CAD',
+  AU: 'AUD', CH: 'CHF', KR: 'KRW', SG: 'SGD', HK: 'HKD',
+}
+
+function guessCurrencyCode(): string {
+  const region = new Intl.Locale(navigator.language).maximize().region
+  const code = region ? LOCALE_CURRENCY[region] : undefined
+  return code && SUPPORTED_CURRENCY_CODES.has(code) ? code : 'USD'
+}
+
+let budgetFileCache: BudgetFile | null = null
+
+/** Resolve the caller's default budget file, creating one if none exists. */
+export const getDefaultBudgetFile = async (): Promise<BudgetFile> => {
   if (budgetFileCache) return budgetFileCache
 
   const response = await get<PaginatedResponse<BudgetFile> | BudgetFile[]>('/api/v1/finance/budget-files/')
@@ -158,13 +174,29 @@ export const getDefaultBudgetFileId = async () => {
   if (!selected) {
     selected = await post<BudgetFile>('/api/v1/finance/budget-files/', {
       name: 'Primary Budget',
-      currency_code: 'USD',
+      // Follow the browser's locale rather than assuming USD, which is what
+      // made an INR-displaying UI store USD server-side.
+      currency_code: guessCurrencyCode(),
       is_default: true,
     })
   }
 
-  budgetFileCache = selected.id
-  return selected.id
+  budgetFileCache = selected
+  return selected
+}
+
+export const getDefaultBudgetFileId = async () => (await getDefaultBudgetFile()).id
+
+/** Persist the display currency on the budget file so it follows the account. */
+export const updateBudgetFileCurrency = async (currencyCode: string) => {
+  const budgetFile = await getDefaultBudgetFile()
+  if (budgetFile.currency_code === currencyCode) return budgetFile
+
+  const updated = await patch<BudgetFile>(`/api/v1/finance/budget-files/${budgetFile.id}/`, {
+    currency_code: currencyCode,
+  })
+  budgetFileCache = updated
+  return updated
 }
 
 export const listAccounts = async (budgetFileId?: number) => {

--- a/web/app/pages/transactions/index.tsx
+++ b/web/app/pages/transactions/index.tsx
@@ -59,6 +59,13 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
+const ORDERING: Record<'newest' | 'oldest' | 'highest' | 'lowest', string> = {
+  newest: '-transaction_date',
+  oldest: 'transaction_date',
+  highest: '-amount',
+  lowest: 'amount',
+}
+
 export default function TransactionsPage() {
   const [showAddTransaction, setShowAddTransaction] = useState(false)
   const [showAddTransfer, setShowAddTransfer] = useState(false)
@@ -70,6 +77,18 @@ export default function TransactionsPage() {
   const [transactionType, setTransactionType] = useState<'all' | 'income' | 'expense'>('all')
   const [sortOrder, setSortOrder] = useState<'newest' | 'oldest' | 'highest' | 'lowest'>('newest')
   const [currentPage, setCurrentPage] = useState(1)
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+
+  // Debounced so typing does not fire a request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery.trim()), 300)
+    return () => clearTimeout(timer)
+  }, [searchQuery])
+
+  // Any filter change invalidates the current page number.
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [debouncedSearch, transactionType, sortOrder, date])
 
   const {
     data: transactions,
@@ -77,6 +96,10 @@ export default function TransactionsPage() {
     mutate: refreshTransactions,
   } = useV1TransactionsList({
     page: currentPage,
+    ...(debouncedSearch ? { search: debouncedSearch } : {}),
+    ...(transactionType !== 'all' ? { type: transactionType } : {}),
+    ...(date ? { start_date: formatDateForApi(date), end_date: formatDateForApi(date) } : {}),
+    ordering: ORDERING[sortOrder],
   })
 
   useEffect(() => {
@@ -126,29 +149,10 @@ export default function TransactionsPage() {
     )
   }
 
-  const filteredTransactions = Array.isArray(transactions?.results)
-    ? transactions?.results
-        ?.filter((transaction) => {
-          const matchesSearch = transaction.title.toLowerCase().includes(searchQuery.toLowerCase())
-          const matchesType = transactionType === 'all' || transaction.type === transactionType
-          const matchesDate = !date || transaction.transaction_date === format(date, 'yyyy-MM-dd')
-          return matchesSearch && matchesType && matchesDate
-        })
-        .sort((a, b) => {
-          switch (sortOrder) {
-            case 'newest':
-              return new Date(b.transaction_date).getTime() - new Date(a.transaction_date).getTime()
-            case 'oldest':
-              return new Date(a.transaction_date).getTime() - new Date(b.transaction_date).getTime()
-            case 'highest':
-              return parseFloat(b.amount) - parseFloat(a.amount)
-            case 'lowest':
-              return parseFloat(a.amount) - parseFloat(b.amount)
-            default:
-              return 0
-          }
-        })
-    : []
+  // Search, type, date and ordering are applied by the API across the whole
+  // ledger. Doing it here only ever filtered the current page, so the result
+  // count disagreed with what was shown.
+  const filteredTransactions = Array.isArray(transactions?.results) ? transactions.results : []
 
   const getCategoryName = (categoryId: number | null | undefined) =>
     categories?.results?.find((category) => category.id === categoryId)?.name || 'Uncategorized'

--- a/web/schema/pft.yaml
+++ b/web/schema/pft.yaml
@@ -3201,6 +3201,18 @@ paths:
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       - name: search
         required: false
         in: query
@@ -3216,9 +3228,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LedgerTransaction'
+                $ref: '#/components/schemas/PaginatedLedgerTransactionList'
           description: ''
     post:
       operationId: v1_finance_transactions_create
@@ -4390,6 +4400,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Category'
+    PaginatedLedgerTransactionList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerTransaction'
     PaginatedTransactionList:
       type: object
       required:


### PR DESCRIPTION
**PR 9 of a stack**, based on #14.

## Currency was cosmetic and internally inconsistent

The UI defaulted to **INR** and offered twelve currencies, while the client hardcoded `currency_code: 'USD'` when it created the budget file. So an INR-displaying app stored USD server-side, and the choice never left the browser — sign in elsewhere and it reverted.

- **The budget file is now the source of truth.** The provider reads `currency_code` on load and writes it back when the user changes currency, so the choice follows the account. `localStorage` stays only as a first-paint cache.
- A newly created budget file derives its currency from the browser locale instead of assuming USD.
- Amounts format through `Intl.NumberFormat` with `style: 'currency'`. The old code hardcoded `en-US` grouping and **prepended the symbol by hand**, so every currency whose symbol is suffixed or whose grouping differs rendered wrong. Chart ticks and tooltips used raw string concatenation (`` `${currency.symbol}${value}` ``) and now format the same way.
- Removes the dead `'currencyChange'` listener — nothing ever dispatched that event — and the `localStorage` write that lived inside `CurrencyDisplay` and fired on **every render of every amount on screen**.

## Transaction filtering only ever saw one page

Search, type, date and sort all ran in the browser over `transactions.results` — the current page — while the footer compared that count against `transactions.count`. The two disagreed, and "highest amount" meant highest *on this page*.

**Backend:**

- The ledger endpoint is now paginated (`page_size`, capped at 500).
- A `type` filter. Income vs expense is a property of the **category on the posting**, not of the transaction, so `type` filters on that category's `kind`.
- Ordering by `amount` via an annotation. A `LedgerTransaction` has no amount column, and the category posting is *negative* for income — so the annotation takes the absolute value, otherwise "highest" would sort income to the bottom.

**Frontend:** the page sends `search`, `type`, `start_date`/`end_date` and `ordering` to the API, debounces the search box (300ms), and resets to page 1 when a filter changes.

## Also

Collapses the **two module-level budget-file caches** into one. `v1.ts` and `finance-client.ts` each kept their own singleton, so they could disagree about which budget file was current.

## Tests

Ten new cases: pagination shape, the page-size cap, both type filters, search, date range, ordering by date, ordering by absolute amount (the sign trap above), combined filters, and a malformed date returning 400.

66 backend tests pass, `ruff check` clean, web lint and build clean, schema regenerated and parity still reports zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)