### PR TITLE
feat(import): surface bank statement import in the UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,5 +127,6 @@ start, these are all real and self-contained:
   `web/app/components/ui/currency-display.tsx` with
   `Intl.NumberFormat(locale, { style: 'currency' })`, including the chart tooltips.
 - Register the finance models in `api/pft/admin.py`.
-- Implement the account-deletion flow behind the disabled button in
-  `web/app/pages/settings/index.tsx`.
+- Surface envelope budgeting in the UI: `BudgetMonth` and `EnvelopeAssignment`
+  with goals and carryover are fully implemented in the API.
+- Add a backup/restore screen for `/api/v1/finance/backups/`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ fintrack/
 - Dashboard with balance, income and expense cards over a selectable date range
 - Transaction list with search, filtering, sorting and pagination
 - Export transactions as CSV or JSON from the UI
+- Import bank statements: CSV, OFX, QFX, QIF, CAMT.053 and YNAB, with a preview
+  step and duplicate detection
 - Rules and recurring (scheduled) transactions
 - Reports: net worth, cash flow, spending trends
 - Light/dark mode, responsive layout, currency symbol selection
@@ -95,7 +97,6 @@ fintrack/
 **Implemented in the API but not yet exposed in the UI** — these are good places to
 contribute, because the backend already works:
 
-- Bank statement import (CSV, OFX, QFX, QIF, CAMT.053, YNAB)
 - Envelope budgeting with goals and carryover
 - Server-side exports including XLSX
 - Encrypted backup bundles

--- a/web/app/components/import-transactions-dialog.tsx
+++ b/web/app/components/import-transactions-dialog.tsx
@@ -1,0 +1,237 @@
+import { useInvalidateTransactions } from '@/client/pft/v1/v1'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  IMPORT_FORMATS,
+  createImportJob,
+  executeImportJob,
+  formatFromFilename,
+  previewImportJob,
+  type ImportFormat,
+  type ImportPreview,
+} from '@/lib/import-client'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+// The API caps the payload; mirror it here so a too-large file fails before
+// being read into memory and posted.
+const MAX_BYTES = 5 * 1024 * 1024
+
+type Step = 'choose' | 'preview' | 'importing'
+
+export function ImportTransactionsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [step, setStep] = useState<Step>('choose')
+  const [format, setFormat] = useState<ImportFormat>('csv')
+  const [filename, setFilename] = useState('')
+  const [payload, setPayload] = useState('')
+  const [preview, setPreview] = useState<ImportPreview | null>(null)
+  const [jobId, setJobId] = useState<number | null>(null)
+  const [busy, setBusy] = useState(false)
+  const invalidateTransactions = useInvalidateTransactions()
+
+  const reset = () => {
+    setStep('choose')
+    setFormat('csv')
+    setFilename('')
+    setPayload('')
+    setPreview(null)
+    setJobId(null)
+    setBusy(false)
+  }
+
+  const close = () => {
+    onOpenChange(false)
+    reset()
+  }
+
+  const onFileSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (file.size > MAX_BYTES) {
+      toast.error(`That file is larger than the ${MAX_BYTES / 1024 / 1024}MB import limit.`)
+      return
+    }
+
+    setFilename(file.name)
+    setFormat(formatFromFilename(file.name))
+    setPayload(await file.text())
+  }
+
+  const runPreview = async () => {
+    setBusy(true)
+    try {
+      const job = await createImportJob(format, filename || 'statement', payload)
+      const summary = await previewImportJob(job.id)
+      setJobId(job.id)
+      setPreview(summary)
+      setStep('preview')
+
+      if (summary.detected_rows === 0) {
+        toast.warning('No transactions were found in that file. Check the format.')
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as { errorMessage?: string })?.errorMessage ?? 'Could not read that file.'
+      toast.error(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const runImport = async () => {
+    if (!jobId) return
+    setStep('importing')
+    setBusy(true)
+    try {
+      const result = await executeImportJob(jobId)
+      await invalidateTransactions()
+      const skipped = result.skipped ? `, ${result.skipped} already present` : ''
+      toast.success(`Imported ${result.created} transaction(s)${skipped}.`)
+      close()
+    } catch (error: unknown) {
+      const message =
+        (error as { errorMessage?: string })?.errorMessage ?? 'The import failed.'
+      toast.error(message)
+      setStep('preview')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <DialogContent className='max-w-2xl'>
+        <DialogHeader>
+          <DialogTitle>Import transactions</DialogTitle>
+          <DialogDescription>
+            Import a statement from your bank. Transactions already present are skipped, so
+            re-importing an overlapping file will not create duplicates.
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'choose' && (
+          <div className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='import-file'>Statement file</Label>
+              <Input
+                id='import-file'
+                type='file'
+                accept='.csv,.ofx,.qfx,.qif,.xml,.json,.txt'
+                onChange={onFileSelected}
+              />
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='import-format'>Format</Label>
+              <Select value={format} onValueChange={(value) => setFormat(value as ImportFormat)}>
+                <SelectTrigger id='import-format'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {IMPORT_FORMATS.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label} — {item.hint}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className='text-xs text-muted-foreground'>
+                Detected from the file extension; change it if your bank uses a different one.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {step !== 'choose' && preview && (
+          <div className='space-y-3'>
+            <p className='text-sm'>
+              Found <span className='font-semibold'>{preview.detected_rows}</span> transaction(s)
+              in <span className='font-mono'>{filename}</span>.
+              {preview.detected_rows > preview.sample.length &&
+                ` Showing the first ${preview.sample.length}.`}
+            </p>
+
+            <div className='max-h-72 overflow-y-auto rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Payee</TableHead>
+                    <TableHead>Memo</TableHead>
+                    <TableHead className='text-right'>Amount</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {preview.sample.map((row, index) => (
+                    <TableRow key={`${row.date}-${index}`}>
+                      <TableCell>{row.date}</TableCell>
+                      <TableCell>{row.payee || '—'}</TableCell>
+                      <TableCell>{row.memo || '—'}</TableCell>
+                      <TableCell className='text-right font-mono'>{row.amount}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          {step === 'choose' ? (
+            <>
+              <Button variant='outline' onClick={close} disabled={busy}>
+                Cancel
+              </Button>
+              <Button onClick={runPreview} disabled={!payload || busy}>
+                {busy ? 'Reading...' : 'Preview'}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant='outline' onClick={() => setStep('choose')} disabled={busy}>
+                Back
+              </Button>
+              <Button
+                onClick={runImport}
+                disabled={busy || !preview || preview.detected_rows === 0}
+              >
+                {step === 'importing' ? 'Importing...' : `Import ${preview?.detected_rows ?? 0}`}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/app/lib/import-client.test.ts
+++ b/web/app/lib/import-client.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { IMPORT_FORMATS, formatFromFilename } from './import-client'
+
+describe('formatFromFilename', () => {
+  it.each([
+    ['statement.csv', 'csv'],
+    ['export.ofx', 'ofx'],
+    ['quicken.qfx', 'qfx'],
+    ['register.qif', 'qif'],
+  ])('maps %s to %s', (filename, expected) => {
+    expect(formatFromFilename(filename)).toBe(expected)
+  })
+
+  it('treats .xml as CAMT.053, which is how banks ship ISO 20022', () => {
+    expect(formatFromFilename('camt.53.xml')).toBe('camt053')
+  })
+
+  it('treats .json as an nYNAB export', () => {
+    expect(formatFromFilename('budget.json')).toBe('nynab')
+  })
+
+  it('is case insensitive', () => {
+    expect(formatFromFilename('STATEMENT.CSV')).toBe('csv')
+  })
+
+  it('handles a name with several dots', () => {
+    expect(formatFromFilename('2026.03.statement.ofx')).toBe('ofx')
+  })
+
+  it('falls back to CSV for an unknown or missing extension', () => {
+    expect(formatFromFilename('statement')).toBe('csv')
+    expect(formatFromFilename('statement.weird')).toBe('csv')
+  })
+})
+
+describe('IMPORT_FORMATS', () => {
+  it('matches the formats the API accepts', () => {
+    expect(IMPORT_FORMATS.map((item) => item.value)).toEqual([
+      'csv',
+      'ofx',
+      'qfx',
+      'qif',
+      'camt053',
+      'ynab4',
+      'nynab',
+    ])
+  })
+
+  it('labels and hints every format', () => {
+    for (const item of IMPORT_FORMATS) {
+      expect(item.label).toBeTruthy()
+      expect(item.hint).toBeTruthy()
+    }
+  })
+})

--- a/web/app/lib/import-client.ts
+++ b/web/app/lib/import-client.ts
@@ -1,0 +1,97 @@
+import { httpPFTClient } from '@/client/httpPFTClient'
+import { getDefaultBudgetFileId } from '@/lib/finance-client'
+
+/**
+ * Bank statement import.
+ *
+ * The backend has parsed CSV, OFX, QFX, QIF, CAMT.053 and YNAB exports since
+ * the finance domain landed, but nothing in the UI ever called it. This is the
+ * three-step flow it expects: create the job, preview what was parsed, then
+ * execute it.
+ */
+
+export const IMPORT_FORMATS = [
+  { value: 'csv', label: 'CSV', hint: 'date, payee, memo, amount' },
+  { value: 'ofx', label: 'OFX', hint: 'Open Financial Exchange' },
+  { value: 'qfx', label: 'QFX', hint: 'Quicken' },
+  { value: 'qif', label: 'QIF', hint: 'Quicken Interchange' },
+  { value: 'camt053', label: 'CAMT.053', hint: 'ISO 20022 bank statement' },
+  { value: 'ynab4', label: 'YNAB 4', hint: 'YNAB register export' },
+  { value: 'nynab', label: 'nYNAB', hint: 'YNAB (new) register export' },
+] as const
+
+export type ImportFormat = (typeof IMPORT_FORMATS)[number]['value']
+
+export interface ImportPreviewRow {
+  date: string
+  payee: string
+  memo: string
+  amount: string
+}
+
+export interface ImportPreview {
+  format: string
+  detected_rows: number
+  sample: ImportPreviewRow[]
+  unsupported: boolean
+}
+
+export interface ImportJob {
+  id: number
+  budget_file: number
+  format: string
+  status: string
+  source_filename: string
+  preview_summary: ImportPreview | null
+  error_message: string
+}
+
+export interface ImportResult {
+  created: number
+  skipped: number
+  [key: string]: unknown
+}
+
+/** Guess the format from the file extension, falling back to CSV. */
+export function formatFromFilename(filename: string): ImportFormat {
+  const extension = filename.split('.').pop()?.toLowerCase() ?? ''
+  const known = IMPORT_FORMATS.find((item) => item.value === extension)
+  if (known) return known.value
+  if (extension === 'xml') return 'camt053'
+  if (extension === 'json') return 'nynab'
+  return 'csv'
+}
+
+export async function createImportJob(
+  format: ImportFormat,
+  filename: string,
+  payload: string,
+): Promise<ImportJob> {
+  const budgetFileId = await getDefaultBudgetFileId()
+  return httpPFTClient<ImportJob>({
+    url: '/api/v1/finance/imports/',
+    method: 'POST',
+    data: {
+      budget_file: budgetFileId,
+      format,
+      source_filename: filename,
+      source_payload: payload,
+    },
+  })
+}
+
+export async function previewImportJob(id: number): Promise<ImportPreview> {
+  return httpPFTClient<ImportPreview>({
+    url: `/api/v1/finance/imports/${id}/preview/`,
+    method: 'POST',
+    data: {},
+  })
+}
+
+export async function executeImportJob(id: number): Promise<ImportResult> {
+  return httpPFTClient<ImportResult>({
+    url: `/api/v1/finance/imports/${id}/execute/`,
+    method: 'POST',
+    data: {},
+  })
+}

--- a/web/app/pages/transactions/index.tsx
+++ b/web/app/pages/transactions/index.tsx
@@ -8,6 +8,7 @@ import { AddTransactionDialog } from '@/components/add-transaction-dialog'
 import { AddTransferDialog } from '@/components/add-transfer-dialog'
 import { DeleteTransactionAlert } from '@/components/delete-transaction-alert'
 import { EditTransactionDialog } from '@/components/edit-transaction-dialog'
+import { ImportTransactionsDialog } from '@/components/import-transactions-dialog'
 import { AnimateSpinner } from '@/components/spinner'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
@@ -55,6 +56,7 @@ import {
   Repeat,
   Search,
   Trash,
+  Upload,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -70,6 +72,7 @@ const ORDERING: Record<'newest' | 'oldest' | 'highest' | 'lowest', string> = {
 export default function TransactionsPage() {
   const [showAddTransaction, setShowAddTransaction] = useState(false)
   const [showAddTransfer, setShowAddTransfer] = useState(false)
+  const [showImport, setShowImport] = useState(false)
   const [showEditTransaction, setShowEditTransaction] = useState(false)
   const [showDeleteAlert, setShowDeleteAlert] = useState(false)
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null)
@@ -143,9 +146,18 @@ export default function TransactionsPage() {
           icon={<CircleDollarSign className='w-12 h-12' />}
           title='No transactions yet'
           description='Start tracking your finances by adding your first transaction.'
-          action={<Button onClick={() => setShowAddTransaction(true)}>Add Transaction</Button>}
+          action={
+            <div className='flex gap-2'>
+              <Button onClick={() => setShowAddTransaction(true)}>Add Transaction</Button>
+              <Button variant='outline' onClick={() => setShowImport(true)}>
+                <Upload className='mr-2 h-4 w-4' />
+                Import statement
+              </Button>
+            </div>
+          }
         />
         <AddTransactionDialog open={showAddTransaction} onOpenChange={setShowAddTransaction} />
+        <ImportTransactionsDialog open={showImport} onOpenChange={setShowImport} />
       </div>
     )
   }
@@ -184,6 +196,10 @@ export default function TransactionsPage() {
       <div className='flex items-center justify-between'>
         <Typography variant='h2'>Transactions</Typography>
         <div className='flex items-center gap-2'>
+          <Button variant='outline' onClick={() => setShowImport(true)}>
+            <Upload className='mr-2 h-4 w-4' />
+            Import
+          </Button>
           <Button variant='outline' onClick={() => setShowAddTransfer(true)}>
             <Repeat className='mr-2 h-4 w-4' />
             Add Transfer
@@ -399,6 +415,7 @@ export default function TransactionsPage() {
       </div>
 
       <AddTransactionDialog open={showAddTransaction} onOpenChange={setShowAddTransaction} />
+      <ImportTransactionsDialog open={showImport} onOpenChange={setShowImport} />
       <AddTransferDialog
         open={showAddTransfer}
         onOpenChange={setShowAddTransfer}

--- a/web/e2e/import.spec.ts
+++ b/web/e2e/import.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Bank statement import.
+ *
+ * The parsers have existed in the API since the finance domain landed, but no
+ * UI ever called them. This drives the whole three-step flow against a real
+ * stack: upload, preview what was parsed, then import.
+ */
+
+const PASSWORD = 'Sup3rSecret!pass'
+
+const CSV = `date,payee,memo,amount
+2026-03-01,Acme Corp,March salary,4200.00
+2026-03-03,Green Grocer,Weekly shop,-82.45
+2026-03-07,Metro Transit,Monthly pass,-55.00
+`
+
+function uniqueEmail() {
+  return `e2e-import-${Date.now()}-${Math.floor(Math.random() * 100000)}@example.com`
+}
+
+test('import a CSV statement and see the transactions appear', async ({ page }) => {
+  const email = uniqueEmail()
+
+  await test.step('register and sign in', async () => {
+    await page.goto('/register')
+    await page.locator('#email').fill(email)
+    await page.locator('#password').fill(PASSWORD)
+    await page.getByRole('button', { name: 'Sign Up' }).click()
+    await page.waitForURL(/\/login/, { timeout: 30_000 })
+
+    await expect(page.locator('#password')).toBeVisible({ timeout: 20_000 })
+    await page.locator('#email').fill(email)
+    await page.locator('#password').fill(PASSWORD)
+    await page.getByRole('button', { name: /login/i }).click()
+    await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 30_000 })
+  })
+
+  await test.step('open the importer from the empty state', async () => {
+    await page.goto('/transactions')
+    await page.getByRole('button', { name: /import/i }).first().click()
+    await expect(page.getByRole('heading', { name: 'Import transactions' })).toBeVisible()
+  })
+
+  await test.step('upload the statement', async () => {
+    await page.locator('#import-file').setInputFiles({
+      name: 'march-statement.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(CSV),
+    })
+    await page.getByRole('button', { name: 'Preview' }).click()
+  })
+
+  await test.step('the preview reports what was parsed', async () => {
+    await expect(page.getByText(/Found\s+3\s+transaction/)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('Acme Corp')).toBeVisible()
+    await expect(page.getByText('Green Grocer')).toBeVisible()
+  })
+
+  await test.step('import them', async () => {
+    await page.getByRole('button', { name: /^Import 3$/ }).click()
+    await expect(page.getByText(/Imported 3 transaction/)).toBeVisible({ timeout: 30_000 })
+  })
+
+  await test.step('they show up in the list', async () => {
+    await expect(page.getByText('March salary').first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText('Weekly shop').first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
**PR 11 of a stack**, based on #16.

## Why

The API has parsed **CSV, OFX, QFX, QIF, CAMT.053 and YNAB** exports since the finance domain landed — with duplicate detection and a preview step — but **nothing in the UI ever called any of it**. `finance_services.py` carries six parsers that no user could reach. The feature audit lists `data_import_csv_bank` as `Missing`, and from a user's point of view it was.

This is the highest-value kind of change available here: the backend work is already done and tested, it just wasn't reachable.

## What it does

A three-step dialog matching the API's flow — create the job, preview, execute. The preview shows the detected row count and a sample table **before anything is written**, so a mis-detected format is visible up front rather than discovered afterwards.

- **Format is inferred from the extension** and can be overridden, since banks are inconsistent. `.xml` → CAMT.053, `.json` → nYNAB, unknown → CSV.
- **File size is checked client-side** against the same limit the API enforces, so an oversized statement fails before being read into memory and posted.
- **Offered from the empty state as well as the toolbar.** An account with no transactions is exactly when importing a statement is most useful, and the page returns early on that state — so the toolbar button alone would have been unreachable for new users.
- Existing transactions are skipped via the API's match key, so re-importing an overlapping statement doesn't duplicate. The result toast reports both counts.

## Tests

11 unit cases for extension detection and the format list, plus an **end-to-end spec against a real stack**: uploads a three-row CSV, asserts the preview reports 3 rows and shows the parsed payees, imports, and checks the transactions appear in the list.

```
✓ import a CSV statement and see the transactions appear (2.6s)
✓ the health endpoint is reachable through the proxy
✓ an anonymous visitor is sent to the login page
✓ register, sign in, add a transaction, and see it listed
4 passed
```

47 unit tests pass; lint and build clean. README moves import from "in the API but not the UI" to "works today".

🤖 Generated with [Claude Code](https://claude.com/claude-code)