### PR TITLE
chore(landing): enforce typecheck in next build

### DIFF
--- a/landing/next.config.mjs
+++ b/landing/next.config.mjs
@@ -3,9 +3,6 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
Removes `typescript.ignoreBuildErrors` from `landing/next.config.mjs` now that the landing codebase typechecks clean (verified with `tsc --noEmit` and `next build` locally). With this, `next build` fails on new type errors instead of silently shipping them — which matters since dependency bumps land regularly via Dependabot.

Follow-up from merging the 10 open Dependabot PRs earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9wEmyLGEFkqMx5EThGgrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9wEmyLGEFkqMx5EThGgrG)_