### PR TITLE
docs: double-entry explainer, ADR process, licensing decision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,13 @@ Optionally install the git hooks so formatting and secret scanning run locally:
 uv run pre-commit install
 ```
 
+## Sign your commits (DCO)
+
+FinTrack uses the [Developer Certificate of Origin](https://developercertificate.org/)
+rather than a CLA. Add a `Signed-off-by` line to each commit — `git commit -s`
+does it for you. See [docs/adr/0001-licensing.md](docs/adr/0001-licensing.md)
+for why.
+
 ## Conventions
 
 - **Commits** follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ Contributions, issues, and feature requests are welcome! Please read the
 4. Push the branch (`git push origin feature/amazing-feature`)
 5. Open a pull request
 
+## 📚 Documentation
+
+| | |
+|---|---|
+| [How double-entry works, for developers](docs/blog/double-entry-for-developers.md) | The mental model behind the ledger — start here |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | How the system fits together, and why there are two API surfaces |
+| [docs/self-hosting.md](docs/self-hosting.md) | Reverse proxy, TLS, backups, upgrades, monitoring |
+| [SECURITY.md](SECURITY.md) | Hardening checklist, private reporting, known limitations |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, conventions, good first issues |
+| [docs/adr/](docs/adr/) | Architecture decision records, including [licensing](docs/adr/0001-licensing.md) |
+
+---
+
 ## 🔒 Security
 
 FinTrack stores personal financial data — please report vulnerabilities

--- a/docs/adr/0000-adr-process.md
+++ b/docs/adr/0000-adr-process.md
@@ -1,0 +1,36 @@
+# ADR-0000: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+
+## Context
+
+Architectural reasoning currently lives in commit messages, pull request
+descriptions and one contributor's head. The next maintainer inherits
+archaeology instead of reasoning, and recurring debates ("why two API
+surfaces?", "why MIT?") get re-litigated because nothing records why the
+decision went the way it did.
+
+## Decision
+
+Significant architectural decisions are recorded as Architecture Decision
+Records in `docs/adr/`, numbered sequentially, in the format used by this file:
+Status, Date, Context, Decision, Consequences.
+
+"Significant" means: anything that changes the data model, the public API
+surface, the licence, the security model, or a load-bearing dependency.
+Renames, refactors and feature work do not need an ADR.
+
+An ADR is proposed as a pull request. Discussion happens on the PR; merging it
+marks the decision **Accepted**. A superseded ADR is not edited — a new ADR
+references and supersedes it, so the history of reversals stays readable.
+
+For larger changes that need design discussion *before* a decision (the
+data-model consolidation, the monorepo restructure), open a GitHub Discussion
+first and distil the outcome into the ADR.
+
+## Consequences
+
+- `docs/adr/` becomes the first stop for "why is it like this?".
+- Decisions cost one markdown file of overhead, which is the point: cheap
+  enough to actually write, permanent enough to matter.

--- a/docs/adr/0001-licensing.md
+++ b/docs/adr/0001-licensing.md
@@ -1,0 +1,60 @@
+# ADR-0001: Licensing — MIT now, open-core boundary decided before monetisation
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Deciders:** Maintainer
+
+## Context
+
+FinTrack is MIT-licensed today. The project intends to (a) grow an outside
+contributor base, and (b) eventually fund maintenance through a commercial
+offering (see the strategy memo: open core, with hosted and team/enterprise
+tiers).
+
+Licence changes become progressively harder as contributors accumulate:
+without a CLA, relicensing requires the agreement of every copyright holder.
+That makes "decide later" a decision in itself — and the wrong one. Recent
+history (Elastic, HashiCorp, Redis) also shows that switching an established
+project *away* from an open licence burns community goodwill at exactly the
+moment a project depends on it.
+
+The options considered:
+
+| Option | Effect | Assessment |
+|---|---|---|
+| MIT everywhere (status quo) | Maximum adoption; no protection against a hosted clone | Right for now; risk is theoretical until the project has traction worth cloning |
+| AGPL-3.0 for the server | Hosted forks must publish source | Deters some corporate adoption; does not actually stop a determined competitor |
+| BSL / Elastic-style | Blocks competing hosted offerings | Not open source by OSI's definition; goodwill cost exceeds today's revenue at risk (zero) |
+| Open core | Core stays MIT; enterprise modules (SSO/SAML, SCIM, audit export, multi-entity consolidation) are commercially licensed | Compatible with all of the above later; requires the boundary to be stated early |
+
+## Decision
+
+1. **The core remains MIT.** "Core" means: the ledger and every invariant, all
+   importers and exporters, the API, the SDKs, the web UI, and self-hosting
+   with unlimited users, accounts and transactions. This list is a public
+   promise (README/strategy memo) and items do not quietly move off it.
+2. **The open-core boundary is organisational, not functional.** If a future
+   commercial module exists, it will be of the shape "your company as an
+   entity" — SSO/SAML/SCIM, compliance artefacts, consolidated multi-entity
+   reporting, support contracts — never a cap that makes the free product feel
+   broken for an individual.
+3. **Contributions are accepted under the DCO** (Developer Certificate of
+   Origin, `Signed-off-by` line), not a CLA. This is deliberate: it keeps the
+   contribution barrier low *and* it intentionally makes a future move to a
+   non-open licence require community consent. We are binding ourselves to the
+   mast on purpose.
+4. Any commercial module lives in a **separately licensed directory or
+   repository**, clearly marked, so the licence of any given file is never
+   ambiguous.
+
+## Consequences
+
+- A competitor may host FinTrack commercially without contributing back. We
+  accept this; at the current stage, distribution is worth more than
+  protection, and the moat is intended to be correctness, community and
+  cadence rather than the licence.
+- The DCO requirement needs enforcement in CI (a `Signed-off-by` check) and a
+  note in CONTRIBUTING.md.
+- Revisit this ADR when the first commercial module is about to be built —
+  not to change the core licence, but to define the enterprise module licence
+  text. A new ADR should record that decision.

--- a/docs/blog/double-entry-for-developers.md
+++ b/docs/blog/double-entry-for-developers.md
@@ -1,0 +1,172 @@
+# How double-entry bookkeeping works, for developers
+
+*The mental model behind FinTrack's ledger, explained without accounting jargon.*
+
+Most finance apps store money the way a to-do app stores tasks: one row per
+transaction, with an amount and a sign. Spent £40 on groceries? Insert
+`{amount: -40, category: "Food"}`. It works — right up until it doesn't, and
+the ways it stops working are the reason double-entry bookkeeping has survived
+five centuries of better ideas.
+
+This post explains the model FinTrack is built on, why the single-row approach
+breaks, and what the invariant buys you in practice.
+
+## The single-row model, and where it lies to you
+
+Say you track transactions as signed amounts:
+
+```
+date        memo             amount   category
+2026-03-01  Salary          +4200.00  Income
+2026-03-03  Groceries         -82.45  Food
+2026-03-07  Metro pass        -55.00  Transport
+```
+
+Now answer a simple question: **how much money is in your checking account?**
+
+You can't. The rows record *flows* but not *where the money sits*. So you add
+an `account` column. Fine — until you move £500 from checking to savings.
+That's not income and it's not spending, but your schema forces a choice:
+
+- Record it once against checking (`-500`): savings is now wrong.
+- Record it twice (`-500` checking, `+500` savings): your "total spending"
+  reports now double-count every transfer unless every query remembers to
+  exclude them.
+- Add a special `is_transfer` flag: congratulations, you have grown a second
+  schema inside your first one, and every report needs to know about it.
+
+Credit cards make it worse. Paying a £300 credit-card bill from checking is a
+transfer between two accounts — but the £300 of spending already happened,
+last month, at the point of purchase. Single-row schemas routinely count it in
+both places, which is why so many budgeting apps quietly show spending numbers
+that don't add up.
+
+The root problem: **every movement of money has two ends**, and a single-row
+schema records only one of them.
+
+## The double-entry model
+
+Double-entry makes the two ends explicit. A *transaction* is a container; the
+money lives in its *postings*, and every posting says where value came from or
+went to. The one rule — the entire system, really — is:
+
+> **The postings of a transaction must sum to zero.**
+
+Buying £82.45 of groceries from checking:
+
+```
+Transaction: "Green Grocer", 2026-03-03
+  Posting 1:  account = Checking     amount = -82.45
+  Posting 2:  category = Food        amount = +82.45
+                                     ─────────────────
+                                     sum    =   0.00
+```
+
+Money left the checking account (−) and was "consumed" by the Food category
+(+). Nothing appeared or vanished; it moved.
+
+Your salary:
+
+```
+Transaction: "Acme Corp", 2026-03-01
+  Posting 1:  account = Checking     amount = +4200.00
+  Posting 2:  category = Salary      amount = -4200.00
+```
+
+And the transfer that broke the single-row model:
+
+```
+Transaction: "Move to savings", 2026-03-10
+  Posting 1:  account = Checking     amount = -500.00
+  Posting 2:  account = Savings      amount = +500.00
+```
+
+Two *account* postings, no category at all. It is structurally obvious that
+this is neither income nor spending — no flag, no special case, no report that
+needs to remember to exclude it.
+
+## What the invariant buys you
+
+**Balances are derived, never stored.** An account's balance is its opening
+balance plus the sum of its postings. There is no `balance` column to drift out
+of sync, no cache to invalidate, no reconciliation job to run at 3am. If the
+zero-sum rule holds, the balances *cannot* be wrong relative to the
+transactions.
+
+**Errors become loud instead of silent.** In a single-row schema, a bug that
+drops a row just… loses money, invisibly. In double-entry, a bug that writes
+half a transaction violates the invariant and can be rejected *at write time*.
+The failure mode changes from "the numbers drift and nobody notices for six
+months" to "the write fails and you fix the bug today".
+
+**Reports stop being special-cased.** Spending is the sum of postings against
+expense categories. Income is the sum against income categories. Net worth is
+the sum of account balances. Cash flow is postings grouped by month. Every
+report is a filter and a sum over one table — no `is_transfer` exclusions, no
+credit-card double counting.
+
+**Credit cards just work.** A card purchase posts against the card account
+(a liability) and an expense category — spending recorded once, at purchase
+time. Paying the bill is an account-to-account transfer. The two events that
+single-row schemas conflate are two different transactions, because they *are*
+two different events.
+
+## How FinTrack implements it
+
+FinTrack's ledger (see [ARCHITECTURE.md](../../ARCHITECTURE.md) for the full
+model) maps the concepts above almost one-to-one:
+
+- **`LedgerTransaction`** is the container — date, payee, memo, cleared flag.
+- **`LedgerPosting`** carries the money. Each posting references *exactly one*
+  of an account or a category — enforced by a database check constraint, not
+  application code.
+- The **zero-sum rule** is validated on every write through the API
+  (`finance_serializers._validate_postings`). Moving it into the database
+  itself, so that *no* write path can violate it, is tracked in
+  [#49](https://github.com/AshishKapoor/fintrack/issues/49).
+- **Transfers** are two account postings sharing a `transfer_group` id.
+- Accounts are typed (checking, savings, cash, credit, asset, liability), so
+  net worth can subtract liabilities without guessing.
+
+A worked example, as the API sees it:
+
+```json
+POST /api/v1/finance/transactions/
+{
+  "budget_file": 1,
+  "transaction_date": "2026-03-03",
+  "memo": "Green Grocer",
+  "postings": [
+    { "account": 1,  "amount": "-82.45" },
+    { "category": 7, "amount": "82.45" }
+  ]
+}
+```
+
+Send postings that don't sum to zero and you get a 400, not a quietly corrupt
+ledger.
+
+## "Isn't this overkill for personal finance?"
+
+The honest answer: for *recording* your coffee purchases, yes, a signed-amount
+row would do. The model earns its keep at the exact moments personal finance
+stops being trivial — the second account, the first credit card, the first
+transfer, the first time you ask "why doesn't my total match my bank?" —
+which, empirically, is about week three of using any finance app seriously.
+
+FinTrack's UI hides the mechanics for the common case: you type "£82.45,
+Groceries" and the app writes the two postings for you. The double-entry
+structure is there when you need it, invisible when you don't. That's the
+design goal — the correctness of a ledger with the ergonomics of an expense
+tracker.
+
+## Further reading
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — FinTrack's data model, invariants
+  and where they are enforced
+- Martin Fowler's *Accounting Patterns* — the classic treatment of
+  transactions and postings as a design pattern
+- The plain-text accounting community (ledger-cli, hledger, beancount) — the
+  same model, driven from text files
+
+*Questions or corrections? [Open a discussion](https://github.com/AshishKapoor/fintrack/discussions).*


### PR DESCRIPTION
Executes three items from the 30-day list in the strategy memo.

## The explainer

`docs/blog/double-entry-for-developers.md` — "How double-entry bookkeeping works, for developers." The memo calls this the highest-leverage content the project can publish: every reader is a qualified prospect, and it doubles as onboarding for contributors who've never met the ledger model. It walks the single-row schema into the ground (transfers, credit-card double counting), shows what the zero-sum invariant buys (derived balances, loud errors, special-case-free reports), and maps it all onto `LedgerTransaction`/`LedgerPosting` with a real API example. Linked prominently from the README docs table.

## ADRs

- **ADR-0000** adopts the practice: decisions that change the data model, public API, licence, or security model get a numbered record in `docs/adr/`.
- **ADR-0001** settles licensing *before* contributors make it hard to change:
  - **Core stays MIT**, with the never-paywalled list stated as a public promise
  - The open-core boundary, if ever built, is **organisational** (SSO, SCIM, multi-entity consolidation) — never a cap that breaks the free product for individuals
  - **DCO, not CLA** — deliberately low-friction, and deliberately binds the project to community consent for any future licence change

CONTRIBUTING gains the `git commit -s` instruction. (A CI check for the sign-off is follow-up work.)

Docs only — no code paths touched.