### PR TITLE
feat(money): integer minor-unit Money value object with exact allocation

### DIFF
--- a/api/pft/money.py
+++ b/api/pft/money.py
@@ -1,0 +1,231 @@
+"""Money as a value object: integer minor units plus an ISO 4217 currency.
+
+This module is deliberately framework-free - no Django imports - because it is
+the seed of a future standalone ledger-core package (strategy memo §6,
+issue #48). Everything financial that can be represented here should be, so the
+arithmetic rules live in exactly one place.
+
+Why integer minor units rather than Decimal columns:
+
+- Decimal invites arithmetic in whatever layer happens to hold the value, with
+  whatever rounding that layer defaults to. An integer count of cents cannot be
+  half a cent.
+- Different currencies have different exponents. JPY has no minor unit, KWD has
+  three. Code that assumes two decimal places is wrong in ~30 countries; here
+  the exponent travels with the value.
+- Cross-currency arithmetic becomes a type error at the boundary instead of a
+  silent bug: Money(GBP) + Money(USD) raises.
+
+Nothing in this module rounds implicitly. Conversions from Decimal reject
+values with more precision than the currency carries, and splitting an amount
+uses largest-remainder allocation so the parts always sum exactly to the whole.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
+
+# ISO 4217 minor-unit exponents. 2 is the default; only the exceptions are
+# listed. Sources: ISO 4217 amendment list.
+_EXPONENT_EXCEPTIONS = {
+    # Zero-decimal currencies
+    "BIF": 0, "CLP": 0, "DJF": 0, "GNF": 0, "ISK": 0, "JPY": 0, "KMF": 0,
+    "KRW": 0, "PYG": 0, "RWF": 0, "UGX": 0, "VND": 0, "VUV": 0, "XAF": 0,
+    "XOF": 0, "XPF": 0,
+    # Three-decimal currencies
+    "BHD": 3, "IQD": 3, "JOD": 3, "KWD": 3, "LYD": 3, "OMR": 3, "TND": 3,
+}
+
+DEFAULT_EXPONENT = 2
+
+
+def currency_exponent(currency: str) -> int:
+    """Number of minor-unit digits for an ISO 4217 currency code."""
+    return _EXPONENT_EXCEPTIONS.get(currency.upper(), DEFAULT_EXPONENT)
+
+
+class CurrencyMismatch(TypeError):
+    """Raised when arithmetic mixes two different currencies."""
+
+
+class PrecisionError(ValueError):
+    """Raised when a decimal has more precision than the currency carries."""
+
+
+@dataclass(frozen=True, slots=True)
+class Money:
+    """An exact amount of one currency, counted in minor units.
+
+    Money(1234, "GBP") is £12.34. Money(1234, "JPY") is ¥1234.
+    Instances are immutable and hashable; arithmetic returns new instances.
+    """
+
+    minor: int
+    currency: str
+
+    def __post_init__(self):
+        if not isinstance(self.minor, int) or isinstance(self.minor, bool):
+            raise TypeError(f"minor units must be an int, got {type(self.minor).__name__}")
+        code = self.currency.upper()
+        if len(code) != 3 or not code.isalpha():
+            raise ValueError(f"not an ISO 4217 currency code: {self.currency!r}")
+        object.__setattr__(self, "currency", code)
+
+    # ---- Constructors -----------------------------------------------------
+
+    @classmethod
+    def from_decimal(cls, amount: Decimal | str, currency: str) -> Money:
+        """Exact conversion. Rejects excess precision rather than rounding.
+
+        Money.from_decimal("12.34", "GBP") -> 1234 minor
+        Money.from_decimal("12.345", "GBP") -> PrecisionError
+        Use `from_decimal_rounded` when rounding is the caller's explicit intent.
+        """
+        exponent = currency_exponent(currency)
+        try:
+            quantised = Decimal(amount).scaleb(exponent)
+        except InvalidOperation as exc:
+            raise ValueError(f"not a decimal amount: {amount!r}") from exc
+        if quantised != quantised.to_integral_value():
+            raise PrecisionError(
+                f"{amount} has more precision than {currency.upper()} carries "
+                f"({exponent} minor digits)"
+            )
+        return cls(int(quantised), currency)
+
+    @classmethod
+    def from_decimal_rounded(cls, amount: Decimal | str, currency: str) -> Money:
+        """Convert with banker's rounding, for external data that may be dirty."""
+        exponent = currency_exponent(currency)
+        quantised = Decimal(amount).scaleb(exponent).quantize(
+            Decimal(1), rounding=ROUND_HALF_EVEN
+        )
+        return cls(int(quantised), currency)
+
+    @classmethod
+    def zero(cls, currency: str) -> Money:
+        return cls(0, currency)
+
+    # ---- Representation ---------------------------------------------------
+
+    @property
+    def decimal(self) -> Decimal:
+        return Decimal(self.minor).scaleb(-currency_exponent(self.currency))
+
+    def __str__(self) -> str:
+        exponent = currency_exponent(self.currency)
+        if exponent == 0:
+            return f"{self.minor} {self.currency}"
+        return f"{self.decimal:.{exponent}f} {self.currency}"
+
+    # ---- Arithmetic (same-currency only) ----------------------------------
+
+    def _check(self, other: Money) -> None:
+        if not isinstance(other, Money):
+            raise TypeError(f"cannot combine Money with {type(other).__name__}")
+        if other.currency != self.currency:
+            raise CurrencyMismatch(
+                f"cannot combine {self.currency} with {other.currency}; "
+                "convert explicitly first"
+            )
+
+    def __add__(self, other: Money) -> Money:
+        self._check(other)
+        return Money(self.minor + other.minor, self.currency)
+
+    def __sub__(self, other: Money) -> Money:
+        self._check(other)
+        return Money(self.minor - other.minor, self.currency)
+
+    def __neg__(self) -> Money:
+        return Money(-self.minor, self.currency)
+
+    def __abs__(self) -> Money:
+        return Money(abs(self.minor), self.currency)
+
+    def __bool__(self) -> bool:
+        return self.minor != 0
+
+    def __lt__(self, other: Money) -> bool:
+        self._check(other)
+        return self.minor < other.minor
+
+    def __le__(self, other: Money) -> bool:
+        self._check(other)
+        return self.minor <= other.minor
+
+    def __gt__(self, other: Money) -> bool:
+        self._check(other)
+        return self.minor > other.minor
+
+    def __ge__(self, other: Money) -> bool:
+        self._check(other)
+        return self.minor >= other.minor
+
+    def __mul__(self, factor: int) -> Money:
+        if not isinstance(factor, int) or isinstance(factor, bool):
+            raise TypeError(
+                "Money can only be multiplied by an int; for proportional splits "
+                "use allocate(), which never loses a minor unit"
+            )
+        return Money(self.minor * factor, self.currency)
+
+    __rmul__ = __mul__
+
+    # ---- Allocation -------------------------------------------------------
+
+    def allocate(self, weights: Sequence[int]) -> list[Money]:
+        """Split by integer weights with largest-remainder distribution.
+
+        The parts always sum exactly to self - no minor unit is ever created
+        or lost. Ten pounds across [1, 1, 1]:
+
+            Money(1000, "GBP").allocate([1, 1, 1])
+            -> [334, 333, 333]  (not 333.33... anywhere)
+
+        Remainders go to the largest fractional parts first; ties break toward
+        earlier positions, so the result is deterministic.
+        """
+        if not weights:
+            raise ValueError("weights must be non-empty")
+        if any((not isinstance(w, int)) or isinstance(w, bool) or w < 0 for w in weights):
+            raise ValueError("weights must be non-negative ints")
+        total_weight = sum(weights)
+        if total_weight == 0:
+            raise ValueError("weights must not all be zero")
+
+        sign = -1 if self.minor < 0 else 1
+        magnitude = abs(self.minor)
+
+        base_parts, fractions = [], []
+        for index, weight in enumerate(weights):
+            exact = magnitude * weight
+            base, remainder = divmod(exact, total_weight)
+            base_parts.append(base)
+            fractions.append((-(remainder), index))  # most-owed first, stable
+
+        shortfall = magnitude - sum(base_parts)
+        for _, index in sorted(fractions)[:shortfall]:
+            base_parts[index] += 1
+
+        return [Money(sign * part, self.currency) for part in base_parts]
+
+    def split(self, parts: int) -> list[Money]:
+        """Split into `parts` near-equal pieces. Sugar for allocate([1] * parts)."""
+        if parts < 1:
+            raise ValueError("parts must be >= 1")
+        return self.allocate([1] * parts)
+
+
+def total(items: Iterable[Money], currency: str | None = None) -> Money:
+    """Sum an iterable of Money, which may be empty if `currency` is given."""
+    result: Money | None = None
+    for item in items:
+        result = item if result is None else result + item
+    if result is None:
+        if currency is None:
+            raise ValueError("cannot sum an empty iterable without a currency")
+        return Money.zero(currency)
+    return result

--- a/api/pft/tests/test_money.py
+++ b/api/pft/tests/test_money.py
@@ -1,0 +1,133 @@
+"""Property tests for the Money value object.
+
+The claims worth proving, per strategy memo §6:
+
+- conversion is exact: Decimal -> minor units -> Decimal round-trips
+- excess precision is an error, never a silent rounding
+- cross-currency arithmetic is a type error
+- allocation never creates or destroys a minor unit, for any amount and any
+  weights - the defect class where "£10 across 3 envelopes" leaks a penny
+"""
+
+from decimal import Decimal
+from unittest import TestCase
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from pft.money import (
+    CurrencyMismatch,
+    Money,
+    PrecisionError,
+    currency_exponent,
+    total,
+)
+
+MINOR = st.integers(min_value=-10**12, max_value=10**12)
+CURRENCIES = st.sampled_from(["GBP", "USD", "EUR", "INR", "JPY", "KWD", "CLP", "BHD"])
+WEIGHTS = st.lists(st.integers(min_value=0, max_value=1000), min_size=1, max_size=12).filter(
+    lambda ws: sum(ws) > 0
+)
+
+
+class ConstructionTests(TestCase):
+    def test_exact_decimal_conversion(self):
+        self.assertEqual(Money.from_decimal("12.34", "GBP").minor, 1234)
+        self.assertEqual(Money.from_decimal("1234", "JPY").minor, 1234)
+        self.assertEqual(Money.from_decimal("1.234", "KWD").minor, 1234)
+
+    def test_excess_precision_is_an_error_not_a_rounding(self):
+        with self.assertRaises(PrecisionError):
+            Money.from_decimal("12.345", "GBP")
+        with self.assertRaises(PrecisionError):
+            Money.from_decimal("1.5", "JPY")
+
+    def test_explicit_rounding_constructor_exists_for_dirty_data(self):
+        self.assertEqual(Money.from_decimal_rounded("12.345", "GBP").minor, 1234)
+        self.assertEqual(Money.from_decimal_rounded("12.355", "GBP").minor, 1236)
+
+    def test_currency_code_is_validated_and_normalised(self):
+        self.assertEqual(Money(1, "gbp").currency, "GBP")
+        with self.assertRaises(ValueError):
+            Money(1, "POUNDS")
+        with self.assertRaises(TypeError):
+            Money(Decimal("1"), "GBP")
+
+    def test_known_exponents(self):
+        self.assertEqual(currency_exponent("GBP"), 2)
+        self.assertEqual(currency_exponent("JPY"), 0)
+        self.assertEqual(currency_exponent("KWD"), 3)
+
+    @settings(max_examples=200)
+    @given(minor=MINOR, currency=CURRENCIES)
+    def test_decimal_round_trip(self, minor, currency):
+        money = Money(minor, currency)
+        self.assertEqual(Money.from_decimal(money.decimal, currency), money)
+
+
+class ArithmeticTests(TestCase):
+    def test_cross_currency_addition_raises(self):
+        with self.assertRaises(CurrencyMismatch):
+            Money(100, "GBP") + Money(100, "USD")
+        with self.assertRaises(CurrencyMismatch):
+            _ = Money(100, "GBP") < Money(100, "USD")
+
+    def test_adding_a_bare_number_raises(self):
+        with self.assertRaises(TypeError):
+            Money(100, "GBP") + 5  # type: ignore[operator]
+
+    def test_float_multiplication_is_rejected(self):
+        with self.assertRaises(TypeError):
+            Money(100, "GBP") * 0.5  # type: ignore[operator]
+
+    @settings(max_examples=200)
+    @given(a=MINOR, b=MINOR, currency=CURRENCIES)
+    def test_addition_matches_integer_addition(self, a, b, currency):
+        self.assertEqual((Money(a, currency) + Money(b, currency)).minor, a + b)
+
+    @settings(max_examples=100)
+    @given(minor=MINOR, currency=CURRENCIES)
+    def test_negation_is_involutive(self, minor, currency):
+        money = Money(minor, currency)
+        self.assertEqual(money.__neg__().__neg__(), money)
+
+    def test_total_of_empty_needs_a_currency(self):
+        self.assertEqual(total([], currency="GBP"), Money.zero("GBP"))
+        with self.assertRaises(ValueError):
+            total([])
+
+
+class AllocationTests(TestCase):
+    def test_the_ten_pound_example(self):
+        parts = Money(1000, "GBP").allocate([1, 1, 1])
+        self.assertEqual([p.minor for p in parts], [334, 333, 333])
+
+    def test_zero_weight_gets_nothing(self):
+        parts = Money(100, "GBP").allocate([1, 0, 1])
+        self.assertEqual([p.minor for p in parts], [50, 0, 50])
+
+    def test_all_zero_weights_rejected(self):
+        with self.assertRaises(ValueError):
+            Money(100, "GBP").allocate([0, 0])
+
+    @settings(max_examples=300)
+    @given(minor=MINOR, currency=CURRENCIES, weights=WEIGHTS)
+    def test_allocation_conserves_every_minor_unit(self, minor, currency, weights):
+        money = Money(minor, currency)
+        parts = money.allocate(weights)
+        self.assertEqual(sum(p.minor for p in parts), minor)
+        self.assertEqual(len(parts), len(weights))
+
+    @settings(max_examples=200)
+    @given(minor=MINOR, currency=CURRENCIES, parts=st.integers(min_value=1, max_value=24))
+    def test_split_parts_differ_by_at_most_one_minor_unit(self, minor, currency, parts):
+        pieces = Money(minor, currency).split(parts)
+        self.assertEqual(sum(p.minor for p in pieces), minor)
+        magnitudes = [p.minor for p in pieces]
+        self.assertLessEqual(max(magnitudes) - min(magnitudes), 1)
+
+    @settings(max_examples=200)
+    @given(minor=MINOR, currency=CURRENCIES, weights=WEIGHTS)
+    def test_allocation_is_deterministic(self, minor, currency, weights):
+        money = Money(minor, currency)
+        self.assertEqual(money.allocate(weights), money.allocate(weights))


### PR DESCRIPTION
First step of #48, scoped as that issue proposes: **the module and its proofs, no column migration yet**. Stacked on #53 (shares the Hypothesis dev dependency).

## Why

Amounts are Decimal columns and strings today, which invites arithmetic in whatever layer holds the value, with whatever rounding that layer defaults to. Strategy memo §6 calls for integer minor units behind a value object — this is that object, deliberately **framework-free** (no Django imports) because it is the seed of the future `ledger-core` package.

## The API

```python
Money(1234, "GBP")                       # £12.34 — minor units + ISO 4217 code
Money.from_decimal("12.34", "GBP")       # exact; "12.345" raises PrecisionError
Money.from_decimal_rounded("12.345", …)  # banker's rounding, for dirty bank data
Money(1000, "GBP").allocate([1, 1, 1])   # [334, 333, 333] — never loses a penny
Money(100, "GBP") + Money(100, "USD")    # CurrencyMismatch, at the type level
Money(100, "GBP") * 0.5                  # TypeError → "use allocate()"
```

- **Exponents travel with the currency.** JPY = 0 minor digits, KWD = 3; the 23 exceptional currencies are tabled. Nothing assumes two decimal places.
- **Nothing rounds implicitly.** Exact conversion rejects excess precision; rounding requires calling the constructor that says so in its name.
- **Allocation is largest-remainder**: parts always sum exactly to the whole, remainders go to the most-owed positions, ties break deterministically toward earlier positions.

## Proof

~1,500 Hypothesis examples across 8 currencies (including the 0- and 3-exponent ones):

- Decimal → minor → Decimal round-trips exactly
- addition matches integer addition; negation is involutive
- **allocation conserves every minor unit** for arbitrary amounts × arbitrary weight vectors
- `split(n)` parts differ by at most one minor unit
- allocation is deterministic

94 backend tests green, ruff clean.

## Next steps (separate PRs, per #48)

Column migration to minor units (expand-contract), then wiring `finance_services` arithmetic through `Money`.