### PR TITLE
chore: make env bootstrap automatic via setup.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-# Copy to .env (`make bootstrap`) and edit before exposing this instance publicly.
+# Copied to .env automatically by ./setup.sh and the Docker make targets.
+# Edit .env before exposing this instance publicly.
 # docker compose reads this file automatically.
 
 # --- Database -----------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,12 @@ biggest open piece of work.
 The fastest path is Docker:
 
 ```bash
-make bootstrap && make dev
+make dev
 ```
 
-That starts Postgres, the API with autoreload on http://localhost:8000, and the web
-app on http://localhost:5173.
+That creates any missing `.env` files from their examples, then starts Postgres,
+the API with autoreload on http://localhost:8000, and the web app on
+http://localhost:5173.
 
 ### Backend without Docker
 
@@ -80,7 +81,7 @@ docker compose up -d && cd web && pnpm exec playwright install chromium && pnpm 
 And, if you touched anything in the Docker or settings layer:
 
 ```bash
-make bootstrap && docker compose build && docker compose up -d && curl -fsS http://localhost:8000/healthz/
+make build && make up && curl -fsS http://localhost:8000/healthz/
 ```
 
 Optionally install the git hooks so formatting and secret scanning run locally:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 COMPOSE_DEV := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
 help:
-	@echo "bootstrap      - create .env files from the examples (run this first)"
 	@echo "up             - start the stack (production-style settings)"
 	@echo "dev            - start the stack with hot reload and dev settings"
 	@echo "down           - stop the stack"
@@ -13,22 +12,21 @@ help:
 	@echo "test-api       - run the backend smoke tests"
 	@echo "test-api-all   - run the full backend test suite"
 	@echo "feature-audit  - validate the feature matrix and regenerate the parity report"
+	@echo "bootstrap      - create missing .env files (runs automatically before docker targets)"
 
 bootstrap:
-	@test -f .env || cp .env.example .env
-	@test -f web/.env || cp web/.env.example web/.env
-	@echo "Bootstrap complete. Review .env before exposing this instance publicly."
+	@./setup.sh configure
 
-up:
+up: bootstrap
 	docker compose up -d
 
-dev:
+dev: bootstrap
 	$(COMPOSE_DEV) up
 
 down:
 	docker compose down
 
-build:
+build: bootstrap
 	docker compose build
 
 logs:
@@ -37,10 +35,10 @@ logs:
 clean:
 	docker compose down -v --remove-orphans
 
-test-api:
+test-api: bootstrap
 	$(COMPOSE_DEV) run --rm --entrypoint sh migrate -lc "uv run manage.py test pft.tests.test_api_smoke"
 
-test-api-all:
+test-api-all: bootstrap
 	$(COMPOSE_DEV) run --rm --entrypoint sh migrate -lc "uv run manage.py test"
 
 feature-audit:

--- a/README.md
+++ b/README.md
@@ -161,10 +161,12 @@ VITE_BASE_DOMAIN=http://localhost:8000
 ## 🧪 Testing
 
 ```bash
-make bootstrap       # first run: create env files
 make test-api        # API smoke tests
 make test-api-all    # full API test suite
 ```
+
+Missing `.env` files are created automatically (via `./setup.sh configure`)
+before any Docker-based target runs — no separate bootstrap step is needed.
 
 ## 📤 API
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,24 +34,28 @@ require_docker() {
     fi
 }
 
+created_any=0
+
 copy_env() {
     src="$1"
     dest="$2"
-    if [ -f "$dest" ]; then
-        echo "  $dest already exists, leaving it untouched."
-    else
+    if [ ! -f "$dest" ]; then
         cp "$src" "$dest"
         echo "  Created $dest (from $src)."
+        created_any=1
     fi
 }
 
+# Idempotent: existing .env files are never touched, and runs that create
+# nothing stay quiet so this can be invoked before every start.
 configure() {
-    echo "Configuring environment files..."
     copy_env .env.example .env
     copy_env api/.env.example api/.env
     copy_env web/.env.example web/.env
-    echo "Done. Review the generated .env files before exposing this instance publicly"
-    echo "(at minimum, change POSTGRES_PASSWORD in .env)."
+    if [ "$created_any" = 1 ]; then
+        echo "Review the generated .env files before exposing this instance publicly"
+        echo "(at minimum, change POSTGRES_PASSWORD in .env)."
+    fi
 }
 
 start() {


### PR DESCRIPTION
The Makefile's bootstrap target duplicated (and drifted from) setup.sh configure — it never created api/.env. Bootstrap is now owned by setup.sh: 'make bootstrap' delegates to './setup.sh configure', every Docker-based make target (up, dev, build, test-api, test-api-all) depends on it, and configure is quiet when nothing needs creating so it can run before every start. Docs no longer ask for a manual bootstrap step.


Claude-Session: https://claude.ai/code/session_014DeQcRBewscoS1wAjZwskM

## What does this change?

<!-- One or two sentences. Link the issue it closes, if there is one. -->

Closes #

## Why?

<!-- What problem does this solve for someone running FinTrack? -->

## How was it verified?

<!-- Delete what does not apply. -->

- [ ] `cd api && uv run ruff check . && uv run manage.py test`
- [ ] `cd web && pnpm run lint && pnpm run build`
- [ ] `docker compose build && docker compose up -d` and the app works end to end
- [ ] Tried it manually (say what you did)

## Checklist

- [ ] Backend changes to a queryset, serializer or permission come with a
      cross-tenant test in `api/pft/tests/test_tenant_isolation.py`
- [ ] No secrets, `.env` files, or generated clients committed
- [ ] Docs updated if the setup steps or API surface changed
