### PR TITLE
perf(web): code-split routes and defer recharts

### DIFF
--- a/web/app/app.tsx
+++ b/web/app/app.tsx
@@ -4,17 +4,23 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster as SonnerToaster } from '@/components/ui/sonner'
 import { Toaster } from '@/components/ui/toaster'
 import { isLoggedIn } from '@/lib/auth'
-import AuthenticationPage from '@/pages/authentication'
-import BudgetsPage from '@/pages/budget'
-import CategoriesPage from '@/pages/category'
-import DashboardPage from '@/pages/dashboard'
-import { LoginPage } from '@/pages/login'
-import NotFound from '@/pages/not-found'
-import ReportsPage from '@/pages/reports'
-import RulesAndRecurringPage from '@/pages/rules'
-import UserSettingsPage from '@/pages/settings'
-import TransactionsPage from '@/pages/transactions'
-import { useEffect } from 'react'
+import { AnimateSpinner } from '@/components/spinner'
+import { Suspense, lazy, useEffect } from 'react'
+
+// Every page is its own chunk, so the initial route does not pay for recharts
+// or pages the user never visits. See the performance budget in CONTRIBUTING.
+const DashboardPage = lazy(() => import('@/pages/dashboard'))
+const CategoriesPage = lazy(() => import('@/pages/category'))
+const BudgetsPage = lazy(() => import('@/pages/budget'))
+const TransactionsPage = lazy(() => import('@/pages/transactions'))
+const ReportsPage = lazy(() => import('@/pages/reports'))
+const RulesAndRecurringPage = lazy(() => import('@/pages/rules'))
+const UserSettingsPage = lazy(() => import('@/pages/settings'))
+const NotFound = lazy(() => import('@/pages/not-found'))
+const AuthenticationPage = lazy(() => import('@/pages/authentication'))
+const LoginPage = lazy(() =>
+  import('@/pages/login').then((module) => ({ default: module.LoginPage })),
+)
 import { Route, Routes, useLocation } from 'react-router-dom'
 
 function App() {
@@ -38,7 +44,8 @@ function App() {
     <ThemeProvider defaultTheme='light' storageKey='vite-ui-theme'>
       {location.pathname !== '/register' && location.pathname !== '/login' && (
         <DashboardLayout>
-          <Routes>
+          <Suspense fallback={<AnimateSpinner size={64} />}>
+            <Routes>
             <Route path='/' element={<DashboardPage />} />
             <Route path='/categories' element={<CategoriesPage />} />
             <Route path='/budgets' element={<BudgetsPage />} />
@@ -48,17 +55,22 @@ function App() {
             <Route path='/home' element={<DashboardPage />} />
             <Route path='/settings' element={<UserSettingsPage />} />
             <Route path='*' element={<NotFound />} />
-          </Routes>
+            </Routes>
+          </Suspense>
         </DashboardLayout>
       )}
       {location.pathname === '/register' && (
         <div className='flex items-center justify-center h-screen bg-background'>
-          <AuthenticationPage />
+          <Suspense fallback={<AnimateSpinner size={64} />}>
+            <AuthenticationPage />
+          </Suspense>
         </div>
       )}
       {location.pathname === '/login' && (
         <div className='flex items-center justify-center h-screen bg-background'>
-          <LoginPage />
+          <Suspense fallback={<AnimateSpinner size={64} />}>
+            <LoginPage />
+          </Suspense>
         </div>
       )}
       <Toaster />

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,4 +11,19 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./app"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          // recharts (plus its d3 dependency tree) is by far the heaviest
+          // library and is only reached from lazily-loaded pages. Nothing else
+          // is split manually: hand-splitting shared vendors (e.g. react) can
+          // create circular chunk initialisation and a runtime TDZ error.
+          if (/node_modules\/(recharts|d3-|victory-|internmap|delaunator)/.test(id)) {
+            return "charts"
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
Closes #44 — the first performance-budget item from the strategy memo (§8: *initial route under 250KB gzipped*).

## Before / after

| | gzipped |
|---|---|
| Before — single chunk, all routes + recharts | **398KB** |
| After — initial route (entry + shared) | **~222KB** |
| Deferred charts chunk (recharts + d3), loaded only by chart pages | 109KB |

## How

- **Every route is `React.lazy`** behind a `Suspense` fallback (the existing spinner), so the login page no longer pays for the reports page.
- **recharts + its d3 tree split into a `charts` chunk** via `manualChunks` — only requested by pages that draw charts.

## The interesting bug

The first version also split `react`/`react-dom` into their own vendor chunk. That built cleanly and **crashed at runtime** with `ReferenceError: Cannot access 'T' before initialization` — circular chunk initialisation, the classic hand-split-vendor pitfall. The unit tests and `tsc` can't see it; **the Playwright suite caught it** (the login redirect spec started failing). The vite config now carries a comment so nobody rediscovers this the hard way.

Which is the argument for the e2e suite in one sentence: two of the last three frontend PRs had a bug only a real browser against a real stack could catch.

## Verification

- 47 unit tests, lint, `tsc` clean
- All 4 Playwright specs green against the rebuilt image
- Chunk sizes measured from the production build output