### PR TITLE
ci: enforce the DCO sign-off adopted in ADR-0001

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,37 @@
+name: DCO
+
+# ADR-0001 adopts the Developer Certificate of Origin instead of a CLA.
+# This enforces the Signed-off-by line on every commit in a pull request.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by present
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check every commit for a sign-off
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          while read -r sha; do
+            # Merge commits are exempt: they are created by the UI/CLI, not authored.
+            if [ "$(git rev-list --no-walk --merges "$sha" | wc -l)" -gt 0 ]; then
+              continue
+            fi
+            if ! git log -1 --format=%B "$sha" | grep -qi '^Signed-off-by: .\+<.\+>'; then
+              echo "::error::Commit $sha has no Signed-off-by line. Amend with 'git commit -s --amend' or see CONTRIBUTING.md."
+              missing=1
+            fi
+          done < <(git rev-list "$BASE".."$HEAD")
+          exit $missing


### PR DESCRIPTION
ADR-0001 (merged in #52) adopted the Developer Certificate of Origin instead of a CLA, and noted the check needed CI enforcement. This is that check.

- Every non-merge commit in a PR must carry a `Signed-off-by:` line
- Merge commits are exempt (created by the UI, not authored)
- The failure message tells the contributor exactly what to run (`git commit -s --amend`) and points at CONTRIBUTING.md

Deliberately a ~20-line shell step rather than a third-party action: nothing to audit, nothing to supply-chain.

Note: existing open PRs predating the ADR may fail this check on old commits; that's expected and fine — the check applies going forward.