### PR TITLE
feat(jobs): run imports and exports on a Celery worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       DATABASE_PASSWORD: fintrack
       DATABASE_HOST: localhost
       DATABASE_PORT: 5432
+      # No broker in the unit-test job; tasks run inline.
+      CELERY_TASK_ALWAYS_EAGER: "True"
 
     defaults:
       run:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,10 @@ explained in full below.
   rendering and no Node process at runtime.
 - `api/` is Django + Django REST Framework behind gunicorn. Authentication is
   JWT (SimpleJWT); there are no server-side sessions for the API.
+- `worker/` is the same image running Celery against Redis. Import execution
+  and exports run there; job state lives on the `ImportJob`/`ExportJob` rows,
+  which clients poll. With no `REDIS_URL`, tasks run eagerly inline — the test
+  suite and bare-metal trials need no broker.
 - `landing/` is a separate Next.js marketing site. It is **not** part of the
   self-hosted stack and is not referenced by `docker-compose.yml`.
 

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ clean:
 	docker compose down -v --remove-orphans
 
 test-api: bootstrap
-	$(COMPOSE_DEV) run --rm --entrypoint sh migrate -lc "uv run manage.py test pft.tests.test_api_smoke"
+	$(COMPOSE_DEV) run --rm -e CELERY_TASK_ALWAYS_EAGER=True --entrypoint sh migrate -lc "uv run manage.py test pft.tests.test_api_smoke"
 
 test-api-all: bootstrap
-	$(COMPOSE_DEV) run --rm --entrypoint sh migrate -lc "uv run manage.py test"
+	$(COMPOSE_DEV) run --rm -e CELERY_TASK_ALWAYS_EAGER=True --entrypoint sh migrate -lc "uv run manage.py test"
 
 feature-audit:
 	python3 scripts/feature_audit.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,9 +52,11 @@ These are real and tracked, not hidden:
   takeover. They carry `SameSite=Strict`, and `Secure` over HTTPS, but not
   `HttpOnly`. Moving the access token into memory with an HttpOnly refresh
   cookie is planned.
-- **Import and export run synchronously in the request.** Payloads are capped
-  (`FINTRACK_MAX_IMPORT_BYTES`, `FINTRACK_MAX_BACKUP_BYTES`) but there is no
-  background queue, so a large import ties up a worker.
+- **Import execution and exports run on a background worker** (Celery + Redis
+  in the Docker stack). Payloads are capped (`FINTRACK_MAX_IMPORT_BYTES`,
+  `FINTRACK_MAX_BACKUP_BYTES`). Without `REDIS_URL` set (bare-metal trials),
+  tasks fall back to running inline in the request. Import *preview* is a
+  parse-only pass and stays synchronous by design.
 - **`ImportJob.source_payload` retains the raw uploaded bank file** in the
   database as plaintext, as do completed exports. Run
   `manage.py prune_finance_jobs` periodically; see

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,4 @@
+# Import the Celery app on Django startup so @shared_task binds to it.
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/api/app/celery.py
+++ b/api/app/celery.py
@@ -1,0 +1,18 @@
+"""Celery application.
+
+Configuration comes from Django settings under the CELERY_ namespace, so there
+is exactly one place deployment values live. When no broker is configured the
+settings switch the app into eager mode - tasks run inline in the calling
+process - which keeps bare-metal installs and the test suite working with no
+Redis at all.
+"""
+
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+
+app = Celery("fintrack")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/api/app/settings/base.py
+++ b/api/app/settings/base.py
@@ -256,3 +256,18 @@ FINTRACK_MAX_BACKUP_BYTES = int(
 # How long finished import/export jobs keep their payloads. These hold plaintext
 # financial data; `manage.py prune_finance_jobs` clears anything older.
 FINTRACK_JOB_RETENTION_DAYS = int(os.getenv("FINTRACK_JOB_RETENTION_DAYS", 30))
+
+# --- Background jobs ---------------------------------------------------------
+# With REDIS_URL set, imports and exports run on the Celery worker instead of
+# inside the web request. Without it (bare-metal trials, the test suite) tasks
+# run eagerly inline, so nothing requires a broker to merely work.
+REDIS_URL = os.getenv("REDIS_URL")
+
+CELERY_BROKER_URL = REDIS_URL
+CELERY_TASK_ALWAYS_EAGER = env_bool("CELERY_TASK_ALWAYS_EAGER", REDIS_URL is None)
+CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+# Job state lives on the ImportJob/ExportJob rows, not in a result backend.
+CELERY_RESULT_BACKEND = None
+CELERY_TASK_TIME_LIMIT = int(os.getenv("CELERY_TASK_TIME_LIMIT", 600))
+CELERY_WORKER_MAX_TASKS_PER_CHILD = 100

--- a/api/pft/finance_views.py
+++ b/api/pft/finance_views.py
@@ -37,10 +37,8 @@ from .finance_services import (
     compute_net_worth,
     copy_budget_month_from_previous,
     decode_export_job_content,
-    execute_import_job,
     materialize_scheduled_transaction,
     preview_import_job,
-    run_export_job,
     run_report,
     zero_budget_month,
 )
@@ -63,6 +61,7 @@ from .models import (
     TransactionEvent,
     TransactionRule,
 )
+from .tasks import execute_import_job_task, run_export_job_task
 
 
 def parse_iso_date(raw, field_name):
@@ -501,7 +500,9 @@ class ExportJobViewSet(UserScopedModelViewSet):
 
     def perform_create(self, serializer):
         export_job = serializer.save(requested_by=self.request.user)
-        run_export_job(export_job)
+        # Runs on the worker (or inline when CELERY_TASK_ALWAYS_EAGER). The
+        # client polls the job row; download/ answers 409 until completed.
+        run_export_job_task.delay(export_job.id)
 
     @action(detail=True, methods=["get"], url_path="download")
     def download(self, request, pk=None):
@@ -574,6 +575,25 @@ class ImportJobViewSet(UserScopedModelViewSet):
 
     @action(detail=True, methods=["post"], url_path="execute")
     def execute(self, request, pk=None):
+        """Start the import and return 202; poll the job for the outcome.
+
+        Row-by-row execution is the heavy half of importing (preview is a
+        parse-only pass and stays synchronous), so it runs on the worker. The
+        job row carries status and, on completion, created/skipped counts in
+        preview_summary.
+        """
         import_job = self.get_object()
-        result = execute_import_job(import_job)
-        return Response(result)
+        if import_job.status == ImportJob.STATUS_IMPORTING:
+            return Response(
+                {"detail": "Import is already running."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        import_job.status = ImportJob.STATUS_IMPORTING
+        import_job.save(update_fields=["status", "updated_at"])
+        execute_import_job_task.delay(import_job.id)
+
+        import_job.refresh_from_db()
+        return Response(
+            self.get_serializer(import_job).data, status=status.HTTP_202_ACCEPTED
+        )

--- a/api/pft/tasks.py
+++ b/api/pft/tasks.py
@@ -1,0 +1,49 @@
+"""Background tasks for the heavy job types.
+
+Each task is a thin wrapper: the business logic stays in finance_services, and
+job state lives on the ImportJob/ExportJob rows (which the UI polls), not in a
+Celery result backend. Failures mark the row failed with the error message
+instead of leaving it stuck in a running state forever.
+"""
+
+import logging
+
+from celery import shared_task
+
+from .models import ExportJob, ImportJob
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def run_export_job_task(export_job_id: int) -> None:
+    from .finance_services import run_export_job
+
+    try:
+        export_job = ExportJob.objects.get(pk=export_job_id)
+    except ExportJob.DoesNotExist:
+        logger.warning("export job %s vanished before the worker saw it", export_job_id)
+        return
+
+    # run_export_job manages RUNNING/COMPLETED/FAILED itself.
+    run_export_job(export_job)
+
+
+@shared_task
+def execute_import_job_task(import_job_id: int) -> None:
+    from .finance_services import execute_import_job
+
+    try:
+        import_job = ImportJob.objects.get(pk=import_job_id)
+    except ImportJob.DoesNotExist:
+        logger.warning("import job %s vanished before the worker saw it", import_job_id)
+        return
+
+    try:
+        execute_import_job(import_job)
+    except Exception as exc:
+        logger.exception("import job %s failed", import_job_id)
+        import_job.status = ImportJob.STATUS_FAILED
+        import_job.error_message = str(exc)[:2000]
+        import_job.save(update_fields=["status", "error_message", "updated_at"])
+        raise

--- a/api/pft/tests/test_api_finance_v1.py
+++ b/api/pft/tests/test_api_finance_v1.py
@@ -188,7 +188,12 @@ class FinanceApiV1Tests(APITestCase):
             format="json",
         )
         self.assertEqual(export_response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(export_response.data["status"], "completed")
+        # The create response is the pre-enqueue snapshot; the job itself runs
+        # on the worker (inline here, under eager mode). Poll the row, as a
+        # client would.
+        self.assertEqual(export_response.data["status"], "pending")
+        job = self.client.get(f"/api/v1/finance/exports/{export_response.data['id']}/")
+        self.assertEqual(job.data["status"], "completed")
 
         download_response = self.client.get(
             f"/api/v1/finance/exports/{export_response.data['id']}/download/"
@@ -240,13 +245,19 @@ class FinanceApiV1Tests(APITestCase):
         self.assertEqual(preview_response.status_code, status.HTTP_200_OK)
         self.assertEqual(preview_response.data["detected_rows"], 2)
 
+        # Execute is asynchronous: 202 now, outcome on the job row. Tests run
+        # with CELERY_TASK_ALWAYS_EAGER, so by the time the response returns
+        # the "background" work has already happened inline.
         execute_response = self.client.post(
             f"/api/v1/finance/imports/{import_job_id}/execute/",
             {},
             format="json",
         )
-        self.assertEqual(execute_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(execute_response.data["created"], 2)
+        self.assertEqual(execute_response.status_code, status.HTTP_202_ACCEPTED)
+
+        job_response = self.client.get(f"/api/v1/finance/imports/{import_job_id}/")
+        self.assertEqual(job_response.data["status"], ImportJob.STATUS_COMPLETED)
+        self.assertEqual(job_response.data["preview_summary"]["created"], 2)
 
     def test_import_preview_supports_qif_camt_and_ynab(self):
         qif_payload = (

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -5,6 +5,7 @@ description = "FinTrack API - privacy-first, self-hostable personal finance trac
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "celery[redis]>=5.4",
     "django>=5.1.7",
     "django-extensions>=3.2.3",
     "djangorestframework>=3.15.2",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -21,12 +33,104 @@ wheels = [
 ]
 
 [[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
+name = "celery"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "kombu", extra = ["redis"] },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -151,6 +255,7 @@ name = "fintrack-api"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "celery", extra = ["redis"] },
     { name = "django" },
     { name = "django-cors-headers" },
     { name = "django-extensions" },
@@ -171,6 +276,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "celery", extras = ["redis"], specifier = ">=5.4" },
     { name = "django", specifier = ">=5.1.7" },
     { name = "django-cors-headers", specifier = ">=4.7.0" },
     { name = "django-extensions", specifier = ">=3.2.3" },
@@ -300,6 +406,26 @@ wheels = [
 ]
 
 [[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +466,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]
@@ -399,6 +537,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -431,6 +581,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]
@@ -520,6 +679,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -556,12 +724,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
+]
+
+[[package]]
 name = "uritemplate"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0", size = 273898, upload-time = "2021-10-13T11:15:14.84Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c0/7461b49cd25aeece13766f02ee576d1db528f1c37ce69aee300e075b485b/uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e", size = 10356, upload-time = "2021-10-13T11:15:12.316Z" },
+]
+
+[[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
 ]
 
 [[package]]
@@ -576,4 +765,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/9c/57d19fa093bcf5ac61a48087dd44d00655f85421d1aa9722f8befbf3f40a/virtualenv-20.29.3.tar.gz", hash = "sha256:95e39403fcf3940ac45bc717597dba16110b74506131845d9b687d5e73d947ac", size = 4320280, upload-time = "2025-03-06T19:54:19.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/eb/c6db6e3001d58c6a9e67c74bb7b4206767caa3ccc28c6b9eaf4c23fb4e34/virtualenv-20.29.3-py3-none-any.whl", hash = "sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170", size = 4301458, upload-time = "2025-03-06T19:54:16.923Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,15 @@ services:
       - ./api:/app
       - api_run:/app/run
 
+  worker:
+    environment:
+      DJANGO_SETTINGS_MODULE: app.settings.dev
+      DJANGO_ENV: development
+      DEBUG: "True"
+    volumes:
+      - ./api:/app
+      - api_run:/app/run
+
   db:
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-django-env: &django-env
   DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-fintrack_local_dev}
   DATABASE_HOST: db
   DATABASE_PORT: 5432
+  REDIS_URL: redis://redis:6379/0
 
 services:
   api:
@@ -31,6 +32,8 @@ services:
       - "${API_PORT:-8000}:8000"
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
@@ -81,6 +84,42 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: ./api
+    image: ghcr.io/ashishkapoor/fintrack-api:latest
+    pull_policy: build
+    # Same image as the api; only the process differs. Imports and exports run
+    # here so a big statement never ties up a web worker.
+    entrypoint:
+      - sh
+      - -c
+      - /usr/local/bin/wait-for-db.sh && exec uv run celery -A app worker --loglevel=info --concurrency=2
+    environment:
+      <<: *django-env
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - fintrack_network
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--maxmemory", "64mb", "--maxmemory-policy", "noeviction"]
+    networks:
+      - fintrack_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     restart: unless-stopped
 
   db:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -131,7 +131,8 @@ the user when you are done.
 ## Backups
 
 Your data lives in the `postgres_data` volume. Nothing else in the stack holds
-state you cannot rebuild.
+state you cannot rebuild — Redis carries only queued jobs in flight, and a lost
+queue entry just means re-clicking an import.
 
 ### Dumping
 
@@ -206,6 +207,10 @@ docker compose exec api uv run manage.py prune_finance_jobs --days 30
 Add `--dry-run` to see what it would clear.
 
 ## Monitoring
+
+The stack runs five services: `web`, `api`, `worker` (imports and exports),
+`redis` (the job queue) and `db`. `docker compose logs worker` shows job
+processing.
 
 `/healthz/` returns `200` with `{"status": "ok", "database": "ok"}` when the API
 can reach Postgres, and `503` otherwise. It is unauthenticated and contains no

--- a/web/app/components/import-transactions-dialog.tsx
+++ b/web/app/components/import-transactions-dialog.tsx
@@ -121,7 +121,8 @@ export function ImportTransactionsDialog({
       close()
     } catch (error: unknown) {
       const message =
-        (error as { errorMessage?: string })?.errorMessage ?? 'The import failed.'
+        (error as { errorMessage?: string })?.errorMessage ??
+        (error instanceof Error ? error.message : 'The import failed.')
       toast.error(message)
       setStep('preview')
     } finally {

--- a/web/app/lib/import-client.ts
+++ b/web/app/lib/import-client.ts
@@ -88,10 +88,44 @@ export async function previewImportJob(id: number): Promise<ImportPreview> {
   })
 }
 
-export async function executeImportJob(id: number): Promise<ImportResult> {
-  return httpPFTClient<ImportResult>({
+export async function getImportJob(id: number): Promise<ImportJob> {
+  return httpPFTClient<ImportJob>({
+    url: `/api/v1/finance/imports/${id}/`,
+    method: 'GET',
+  })
+}
+
+/**
+ * Start the import (the API answers 202 and runs it on a worker), then poll the
+ * job row until it completes or fails. Polling replaces the old synchronous
+ * call so a large statement no longer ties up a web worker - or this tab.
+ */
+export async function executeImportJob(
+  id: number,
+  { intervalMs = 700, timeoutMs = 120_000 }: { intervalMs?: number; timeoutMs?: number } = {},
+): Promise<ImportResult> {
+  await httpPFTClient<ImportJob>({
     url: `/api/v1/finance/imports/${id}/execute/`,
     method: 'POST',
     data: {},
   })
+
+  const startedAt = Date.now()
+  for (;;) {
+    const job = await getImportJob(id)
+    if (job.status === 'completed') {
+      const summary = (job.preview_summary ?? {}) as Record<string, unknown>
+      return {
+        created: Number(summary.created ?? 0),
+        skipped: Number(summary.skipped_duplicates ?? 0),
+      }
+    }
+    if (job.status === 'failed') {
+      throw new Error(job.error_message || 'The import failed.')
+    }
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('The import is taking too long; check the job status later.')
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
 }


### PR DESCRIPTION
Closes #47 — the last open **Now** item on the [roadmap](https://github.com/AshishKapoor/fintrack/issues/51).

## Why

Import execution and export generation ran **synchronously inside the HTTP request**: a statement parsed and inserted row-by-row in one atomic block while a gunicorn worker was held, with the client's timeout racing the server. Payload caps bounded the damage; the shape was still wrong.

## Design

- **Celery, configured entirely from Django settings** (`CELERY_` namespace). One knob: `REDIS_URL`.
- **Eager fallback**: without `REDIS_URL`, tasks run inline. Bare-metal trials and the unit-test suite need no broker — the async machinery is opt-in infrastructure, not a hard dependency.
- **Job state lives on the rows**, not in a result backend. `ImportJob`/`ExportJob` already had `status`; clients poll the resource they created. No new endpoint shapes.
- **Failures are terminal, not silent**: a task exception marks the row `failed` with the message, instead of a job stuck in `importing` forever.

## API contract change

`POST /finance/imports/{id}/execute/` → **202** with the job (409 if already running). Outcome lands on the row: `status`, plus `created` / `skipped_duplicates` in `preview_summary`. Export create enqueues; `download/` already answered 409 until complete. **Preview stays synchronous by design** — parse-only over a capped payload.

## Stack

`redis` (64MB, `noeviction`) and `worker` join compose — the worker is the same api image running `celery -A app worker`, so there is one image and two processes. Healthchecks wired; dev overlay mounts source into the worker too.

## Frontend

`executeImportJob()` starts the job then polls to completion; the dialog reports the real created/skipped counts from the worker run and surfaces the row's error message on failure.

## Verification

- 76 backend tests green in eager mode (contract tests updated: 202 + poll)
- Full stack booted with worker + redis; **all 4 Playwright specs green against the real async path**, and the worker log shows the e2e's task consumed from Redis:

```
Task pft.tasks.execute_import_job_task[045fb589…] received
Task pft.tasks.execute_import_job_task[045fb589…] succeeded in 0.031s
```

- `docker compose config` validates; CI unit-test job pinned to eager mode explicitly.

With this merged, every Phase 1 engineering item on the roadmap is done or in review: DB-enforced invariant (#53), Money (#54), code-splitting (#57), DCO (#58), background jobs (this).