### PR TITLE
feat(web): transactions surface reads and writes the ledger natively

### DIFF
--- a/web/app/components/add-transaction-dialog.tsx
+++ b/web/app/components/add-transaction-dialog.tsx
@@ -25,14 +25,15 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { CalendarIcon } from 'lucide-react'
 import { format } from 'date-fns'
 import { cn } from '@/lib/utils'
+import { useV1FinanceCategoriesList, v1FinanceTransactionsCreate } from '@/client/gen/pft/v1/v1'
+import { getDefaultBudgetFileId } from '@/lib/finance-client'
 import {
-  useInvalidateTransactions,
-  useV1CategoriesList,
-  useV1TransactionsCreate,
-} from '@/client/pft/v1/v1'
+  buildPostings,
+  resolveDefaultAccountId,
+  useInvalidateLedger,
+  type TransactionKind,
+} from '@/lib/ledger'
 import { toast } from 'sonner'
-import { getUser } from '@/lib/auth'
-import { TypeEnum } from '@/client/pft/typeEnum'
 
 export function AddTransactionDialog({
   open,
@@ -41,41 +42,47 @@ export function AddTransactionDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
-  const [type, setType] = useState<TypeEnum>(TypeEnum.expense)
+  const [kind, setKind] = useState<TransactionKind>('expense')
   const [date, setDate] = useState<Date | undefined>(new Date())
   const [title, setTitle] = useState('')
   const [amount, setAmount] = useState('')
   const [selectedCategory, setSelectedCategory] = useState('')
+  const [saving, setSaving] = useState(false)
 
-  const { data: categories, isLoading: isLoadingCategories } = useV1CategoriesList()
-  const refreshTransactions = useInvalidateTransactions()
-  const { trigger: createTransaction } = useV1TransactionsCreate()
+  // Native finance categories through the generated SDK: the classification
+  // field is `kind`, and ids are CategoryV2 ids. No adapter, no /me round-trip
+  // (the old create path fetched the user only to send an id the API ignored).
+  const { data: categories, isLoading: isLoadingCategories } = useV1FinanceCategoriesList()
+  const refreshLedger = useInvalidateLedger()
 
   const handleCreateTransaction = async () => {
-    if (!date) return
-
+    if (!date || saving) return
+    setSaving(true)
     try {
-      const user = await getUser()
-      await createTransaction({
-        type,
-        title,
-        amount,
-        category: parseInt(selectedCategory),
+      const [budgetFileId, accountId] = await Promise.all([
+        getDefaultBudgetFileId(),
+        resolveDefaultAccountId(),
+      ])
+      await v1FinanceTransactionsCreate({
+        budget_file: budgetFileId,
         transaction_date: format(date, 'yyyy-MM-dd'),
-        user: user.id,
+        memo: title,
+        postings: buildPostings(accountId, parseInt(selectedCategory), amount, kind),
       })
-      await refreshTransactions()
+      await refreshLedger()
       toast.success('Transaction created successfully')
       onOpenChange(false)
       // Reset form
       setTitle('')
       setAmount('')
       setSelectedCategory('')
-      setDate(new Date()) // Reset to today's date
-      setType(TypeEnum.expense)
+      setDate(new Date())
+      setKind('expense')
     } catch (err) {
       console.error('Failed to create transaction:', err)
       toast.error('Failed to create transaction')
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -83,7 +90,9 @@ export function AddTransactionDialog({
     return null
   }
 
-  const filteredCategories = categories?.results?.filter((category) => category.type === type) || []
+  const filteredCategories = (categories ?? []).filter(
+    (category) => category.kind === kind && !category.is_archived,
+  )
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -97,21 +106,21 @@ export function AddTransactionDialog({
             <Label htmlFor='transaction-type'>Transaction Type</Label>
             <RadioGroup
               id='transaction-type'
-              value={type}
+              value={kind}
               onValueChange={(value) => {
-                setType(value as TypeEnum)
+                setKind(value as TransactionKind)
                 setSelectedCategory('')
               }}
-              className='flex'
+              className='flex gap-4'
             >
               <div className='flex items-center space-x-2'>
-                <RadioGroupItem value={TypeEnum.expense} id='expense' />
+                <RadioGroupItem value='expense' id='expense' />
                 <Label htmlFor='expense' className='cursor-pointer'>
                   Expense
                 </Label>
               </div>
-              <div className='flex items-center space-x-2 ml-4'>
-                <RadioGroupItem value={TypeEnum.income} id='income' />
+              <div className='flex items-center space-x-2'>
+                <RadioGroupItem value='income' id='income' />
                 <Label htmlFor='income' className='cursor-pointer'>
                   Income
                 </Label>
@@ -133,8 +142,8 @@ export function AddTransactionDialog({
               id='amount'
               type='number'
               placeholder='0.00'
-              step='0.01'
               min='0'
+              step='0.01'
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
             />
@@ -160,7 +169,7 @@ export function AddTransactionDialog({
               <PopoverTrigger asChild>
                 <Button
                   id='date'
-                  variant={'outline'}
+                  variant='outline'
                   className={cn(
                     'w-full justify-start text-left font-normal',
                     !date && 'text-muted-foreground',
@@ -170,13 +179,8 @@ export function AddTransactionDialog({
                   {date ? format(date, 'PPP') : <span>Pick a date</span>}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className='w-auto p-0' align='start'>
-                <Calendar
-                  mode='single'
-                  selected={date}
-                  onSelect={setDate}
-                  disabled={(date) => date > new Date()}
-                />
+              <PopoverContent className='w-auto p-0'>
+                <Calendar mode='single' selected={date} onSelect={setDate} autoFocus />
               </PopoverContent>
             </Popover>
           </div>
@@ -188,9 +192,9 @@ export function AddTransactionDialog({
           <Button
             type='submit'
             onClick={handleCreateTransaction}
-            disabled={!title || !amount || !selectedCategory}
+            disabled={!title || !amount || !selectedCategory || saving}
           >
-            Save
+            {saving ? 'Saving...' : 'Save'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/app/components/delete-transaction-alert.tsx
+++ b/web/app/components/delete-transaction-alert.tsx
@@ -10,10 +10,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import {
-  useInvalidateTransactions,
-  useV1TransactionsDestroy,
-} from '@/client/pft/v1/v1'
+import { v1FinanceTransactionsDestroy } from '@/client/gen/pft/v1/v1'
+import { useInvalidateLedger } from '@/lib/ledger'
 import { toast } from 'sonner'
 
 export function DeleteTransactionAlert({
@@ -26,13 +24,12 @@ export function DeleteTransactionAlert({
   transactionId: string
   currentPage?: number
 }) {
-  const { trigger: deleteTransaction } = useV1TransactionsDestroy(transactionId)
-  const refreshTransactions = useInvalidateTransactions()
+  const refreshLedger = useInvalidateLedger()
 
   const handleDeleteTransaction = async () => {
     try {
-      await deleteTransaction()
-      await refreshTransactions()
+      await v1FinanceTransactionsDestroy(transactionId)
+      await refreshLedger()
       toast.success('Transaction deleted successfully')
       onOpenChange(false)
     } catch (err) {

--- a/web/app/components/edit-transaction-dialog.tsx
+++ b/web/app/components/edit-transaction-dialog.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import { Transaction } from '@/client/pft/transaction'
-import { TypeEnum } from '@/client/pft/typeEnum'
-
+import type { LedgerTransaction } from '@/client/gen/pft/ledgerTransaction'
+import { useV1FinanceCategoriesList, v1FinanceTransactionsUpdate } from '@/client/gen/pft/v1/v1'
 import {
-  useInvalidateTransactions,
-  useV1CategoriesList,
-  useV1TransactionsUpdate,
-} from '@/client/pft/v1/v1'
+  buildPostings,
+  displayFields,
+  resolveDefaultAccountId,
+  useInvalidateLedger,
+  type TransactionKind,
+} from '@/lib/ledger'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -42,17 +43,16 @@ export function EditTransactionDialog({
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
-  transaction: Transaction
+  transaction: LedgerTransaction
 }) {
-  const [type, setType] = useState<TypeEnum>(TypeEnum.expense)
+  const [kind, setKind] = useState<TransactionKind>('expense')
   const [date, setDate] = useState<Date | undefined>(new Date())
   const [title, setTitle] = useState('')
   const [amount, setAmount] = useState('')
   const [selectedCategory, setSelectedCategory] = useState('')
 
-  const { data: categories, isLoading: isLoadingCategories } = useV1CategoriesList()
-  const refreshTransactions = useInvalidateTransactions()
-  const { trigger: updateTransaction } = useV1TransactionsUpdate(transaction?.id?.toString()) // Ensure id is a string
+  const { data: categories, isLoading: isLoadingCategories } = useV1FinanceCategoriesList()
+  const refreshLedger = useInvalidateLedger()
 
   // Initialize form with transaction data. Deferred a tick so the setState
   // burst runs outside the effect body (react-hooks/set-state-in-effect).
@@ -62,32 +62,34 @@ export function EditTransactionDialog({
 
     function initialise() {
       if (!transaction) return
-      const category = categories?.results?.find((c) => c.id === transaction.category)
-      setType(category?.type || TypeEnum.expense)
-      setTitle(transaction.title || '')
-      setAmount(transaction.amount?.toString() || '')
-      setSelectedCategory(transaction.category?.toString() || '')
+      const display = displayFields(transaction)
+      setKind(display.kind)
+      setTitle(display.title)
+      setAmount(display.amount.toFixed(2))
+      setSelectedCategory(display.categoryId ? String(display.categoryId) : '')
 
       if (transaction.transaction_date) {
         setDate(new Date(transaction.transaction_date))
       }
     }
-  }, [transaction, categories])
+  }, [transaction])
 
   const handleUpdateTransaction = async () => {
     if (!date) return
 
     try {
-      await updateTransaction({
-        type,
-        title,
-        amount,
-        category: parseInt(selectedCategory),
+      // A PUT replaces the posting set wholesale: the API deletes the old legs
+      // and writes the new balanced pair, keeping the invariant intact.
+      const accountLeg = transaction.posting_lines.find((line) => line.account !== null)
+      const accountId = accountLeg?.account ?? (await resolveDefaultAccountId())
+      await v1FinanceTransactionsUpdate(String(transaction.id), {
+        budget_file: transaction.budget_file,
         transaction_date: format(date, 'yyyy-MM-dd'),
-        user: transaction.user,
+        memo: title,
+        postings: buildPostings(accountId, parseInt(selectedCategory), amount, kind),
       })
 
-      await refreshTransactions()
+      await refreshLedger()
 
       toast.success('Transaction updated successfully')
       onOpenChange(false)
@@ -101,7 +103,9 @@ export function EditTransactionDialog({
     return null
   }
 
-  const filteredCategories = categories?.results?.filter((category) => category.type === type) || []
+  const filteredCategories = (categories ?? []).filter(
+    (category) => category.kind === kind && !category.is_archived,
+  )
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -115,21 +119,21 @@ export function EditTransactionDialog({
             <Label htmlFor='transaction-type'>Transaction Type</Label>
             <RadioGroup
               id='transaction-type'
-              value={type}
+              value={kind}
               onValueChange={(value) => {
-                setType(value as TypeEnum)
+                setKind(value as TransactionKind)
                 setSelectedCategory('')
               }}
               className='flex'
             >
               <div className='flex items-center space-x-2'>
-                <RadioGroupItem value={TypeEnum.expense} id='expense' />
+                <RadioGroupItem value='expense' id='expense' />
                 <Label htmlFor='expense' className='cursor-pointer'>
                   Expense
                 </Label>
               </div>
               <div className='flex items-center space-x-2 ml-4'>
-                <RadioGroupItem value={TypeEnum.income} id='income' />
+                <RadioGroupItem value='income' id='income' />
                 <Label htmlFor='income' className='cursor-pointer'>
                   Income
                 </Label>
@@ -187,7 +191,7 @@ export function EditTransactionDialog({
               <SelectContent>
                 {filteredCategories.length === 0 ? (
                   <div className='p-2 text-sm text-center text-muted-foreground'>
-                    No {type === TypeEnum.income ? 'income' : 'expense'} categories found
+                    No {kind} categories found
                   </div>
                 ) : (
                   filteredCategories.map((category) => (

--- a/web/app/components/import-transactions-dialog.tsx
+++ b/web/app/components/import-transactions-dialog.tsx
@@ -1,4 +1,4 @@
-import { useInvalidateTransactions } from '@/client/pft/v1/v1'
+import { useInvalidateLedger } from '@/lib/ledger'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -57,7 +57,7 @@ export function ImportTransactionsDialog({
   const [preview, setPreview] = useState<ImportPreview | null>(null)
   const [jobId, setJobId] = useState<number | null>(null)
   const [busy, setBusy] = useState(false)
-  const invalidateTransactions = useInvalidateTransactions()
+  const invalidateTransactions = useInvalidateLedger()
 
   const reset = () => {
     setStep('choose')

--- a/web/app/lib/ledger.ts
+++ b/web/app/lib/ledger.ts
@@ -1,0 +1,95 @@
+import type { LedgerTransaction } from '@/client/gen/pft/ledgerTransaction'
+import { v1FinanceAccountsCreate, v1FinanceAccountsList } from '@/client/gen/pft/v1/v1'
+import { getDefaultBudgetFileId } from '@/lib/finance-client'
+import { useSWRConfig } from 'swr'
+
+/**
+ * Helpers for reading and writing ledger transactions natively through the
+ * generated SDK. This is the replacement for the legacy-shape adapter in
+ * app/client/pft: pages that use these work in ledger terms (memo, postings,
+ * category legs) and stop pretending the API is flat.
+ */
+
+export type TransactionKind = 'income' | 'expense'
+
+export interface LedgerDisplay {
+  title: string
+  categoryId: number | null
+  categoryName: string
+  amount: number
+  kind: TransactionKind
+}
+
+/**
+ * The category leg carries the classification: negative for income (value
+ * flows out of the income category into the account), positive for spending.
+ */
+export function displayFields(transaction: LedgerTransaction): LedgerDisplay {
+  const categoryLeg = transaction.posting_lines.find((line) => line.category !== null)
+  const raw = Number(categoryLeg?.amount ?? transaction.posting_lines[0]?.amount ?? 0)
+  const kind: TransactionKind = raw < 0 ? 'income' : 'expense'
+  return {
+    title: transaction.memo || `Transaction ${transaction.id}`,
+    categoryId: categoryLeg?.category ?? null,
+    categoryName: categoryLeg?.category_name || '',
+    amount: Math.abs(raw),
+    kind,
+  }
+}
+
+let accountCache: number | null = null
+
+/** Resolve the default account for simple one-account entry, creating on first use. */
+export async function resolveDefaultAccountId(): Promise<number> {
+  if (accountCache) return accountCache
+  const budgetFileId = await getDefaultBudgetFileId()
+  const accounts = await v1FinanceAccountsList()
+  let account = accounts.find((item) => item.budget_file === budgetFileId && !item.is_archived)
+  if (!account) {
+    account = await v1FinanceAccountsCreate({
+      budget_file: budgetFileId,
+      name: 'Cash',
+      type: 'checking',
+      opening_balance: '0.00',
+    })
+  }
+  accountCache = account.id
+  return account.id
+}
+
+/**
+ * Build the balanced posting pair for a simple categorised entry: money moves
+ * between the account and the category, summing to zero by construction.
+ */
+export function buildPostings(
+  accountId: number,
+  categoryId: number,
+  amount: string | number,
+  kind: TransactionKind,
+) {
+  const magnitude = Math.abs(Number(amount || 0)).toFixed(2)
+  const accountAmount = kind === 'income' ? magnitude : `-${magnitude}`
+  const categoryAmount = kind === 'income' ? `-${magnitude}` : magnitude
+  return [
+    { account: accountId, amount: accountAmount, sort_order: 0 },
+    { category: categoryId, amount: categoryAmount, sort_order: 1 },
+  ]
+}
+
+/**
+ * Invalidate every cached transaction list - both the generated SDK's real
+ * finance keys and, during the migration, the adapter's synthetic legacy keys
+ * still used by the dashboard and budget pages.
+ */
+export function useInvalidateLedger() {
+  const { mutate } = useSWRConfig()
+  return () =>
+    mutate(
+      (key) => {
+        const url = Array.isArray(key) ? key[0] : key
+        return typeof url === 'string' && url.includes('/transactions/')
+      },
+      undefined,
+      { revalidate: true },
+    )
+}

--- a/web/app/pages/transactions/index.tsx
+++ b/web/app/pages/transactions/index.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { Transaction } from '@/client/pft/transaction'
-import { TypeEnum } from '@/client/pft/typeEnum'
-
-import { useV1CategoriesList, useV1TransactionsList } from '@/client/pft/v1/v1'
+import type { LedgerTransaction } from '@/client/gen/pft/ledgerTransaction'
+import { useV1FinanceTransactionsList } from '@/client/gen/pft/v1/v1'
+import { displayFields } from '@/lib/ledger'
 import { AddTransactionDialog } from '@/components/add-transaction-dialog'
 import { AddTransferDialog } from '@/components/add-transfer-dialog'
 import { DeleteTransactionAlert } from '@/components/delete-transaction-alert'
@@ -52,14 +51,12 @@ import {
   Filter,
   MoreHorizontal,
   Pencil,
-  Plus,
   Repeat,
   Search,
   Trash,
   Upload,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
 const ORDERING: Record<'newest' | 'oldest' | 'highest' | 'lowest', string> = {
@@ -75,7 +72,7 @@ export default function TransactionsPage() {
   const [showImport, setShowImport] = useState(false)
   const [showEditTransaction, setShowEditTransaction] = useState(false)
   const [showDeleteAlert, setShowDeleteAlert] = useState(false)
-  const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null)
+  const [selectedTransaction, setSelectedTransaction] = useState<LedgerTransaction | null>(null)
   const [date, setDate] = useState<Date | undefined>(undefined)
   const [searchQuery, setSearchQuery] = useState('')
   const [transactionType, setTransactionType] = useState<'all' | 'income' | 'expense'>('all')
@@ -103,11 +100,15 @@ export default function TransactionsPage() {
     data: transactions,
     isLoading: isLoadingTransactions,
     mutate: refreshTransactions,
-  } = useV1TransactionsList({
+  } = useV1FinanceTransactionsList({
     page: currentPage,
     ...(debouncedSearch ? { search: debouncedSearch } : {}),
-    ...(transactionType !== 'all' ? { type: transactionType } : {}),
-    ...(date ? { start_date: formatDateForApi(date), end_date: formatDateForApi(date) } : {}),
+    // These are querystring filters the endpoint supports beyond the generated
+    // params type (type / date range); the SDK passes unknown params through.
+    ...(transactionType !== 'all' ? ({ type: transactionType } as object) : {}),
+    ...(date
+      ? ({ start_date: formatDateForApi(date), end_date: formatDateForApi(date) } as object)
+      : {}),
     ordering: ORDERING[sortOrder],
   })
 
@@ -117,30 +118,8 @@ export default function TransactionsPage() {
     setCurrentPage(1)
   }
 
-  const { data: categories, isLoading: isLoadingCategories } = useV1CategoriesList()
-
-  if (isLoadingTransactions || isLoadingCategories) {
+  if (isLoadingTransactions) {
     return <AnimateSpinner size={64} />
-  }
-
-  // Check if there are any categories first
-  if (!categories?.results?.length) {
-    return (
-      <div className='p-6'>
-        <EmptyPlaceholder
-          icon={<CircleDollarSign className='w-12 h-12' />}
-          title='No categories available'
-          description='You need to create categories before adding transactions. Head over to the categories page to create some!'
-          action={
-            <Link to='/categories'>
-              <Button>
-                <Plus className='mr-2 h-4 w-4' /> Create Categories
-              </Button>
-            </Link>
-          }
-        />
-      </div>
-    )
   }
 
   // Show empty state for no transactions
@@ -172,23 +151,23 @@ export default function TransactionsPage() {
   // count disagreed with what was shown.
   const filteredTransactions = Array.isArray(transactions?.results) ? transactions.results : []
 
-  const getCategoryName = (categoryId: number | null | undefined) =>
-    categories?.results?.find((category) => category.id === categoryId)?.name || 'Uncategorized'
-
   const exportTransactions = (format: 'csv' | 'json') => {
     if (!filteredTransactions.length) {
       toast.error('No transactions available for export')
       return
     }
 
-    const rows = filteredTransactions.map((transaction) => ({
-      id: transaction.id,
-      date: transaction.transaction_date,
-      title: transaction.title,
-      category: getCategoryName(transaction.category),
-      type: transaction.type,
-      amount: transaction.amount,
-    }))
+    const rows = filteredTransactions.map((transaction) => {
+      const display = displayFields(transaction)
+      return {
+        id: transaction.id,
+        date: transaction.transaction_date,
+        title: display.title,
+        category: display.categoryName || 'Uncategorized',
+        type: display.kind,
+        amount: display.amount.toFixed(2),
+      }
+    })
 
     const { content, mimeType, extension } = serializeExport(rows, format)
     const filename = `fintrack-transactions-${formatDateForApi(new Date())}.${extension}`
@@ -325,20 +304,21 @@ export default function TransactionsPage() {
               </TableRow>
             ) : (
               filteredTransactions?.map((transaction) => {
-                const category = categories?.results?.find((c) => c.id === transaction.category)
-                const isTransfer = transaction.category === null && /transfer/i.test(transaction.title)
-                const categoryName = isTransfer ? 'Transfer' : category?.name || 'Uncategorized'
+                const display = displayFields(transaction)
+                // A transfer has two account legs and no category leg.
+                const isTransfer = transaction.posting_lines.every((line) => line.category === null)
+                const categoryName = isTransfer ? 'Transfer' : display.categoryName || 'Uncategorized'
 
                 return (
                   <TableRow key={transaction.id}>
                     <TableCell>
                       {format(new Date(transaction.transaction_date), 'dd MMM yyyy')}
                     </TableCell>
-                    <TableCell>{transaction.title}</TableCell>
+                    <TableCell>{display.title}</TableCell>
                     <TableCell>{categoryName}</TableCell>
                     <TableCell>
                       <div className='flex items-center gap-2'>
-                        {transaction.type === TypeEnum.income ? (
+                        {display.kind === 'income' ? (
                           <ArrowUpIcon className='h-4 w-4 text-emerald-600' />
                         ) : (
                           <ArrowDownIcon className='h-4 w-4 text-rose-600' />
@@ -346,12 +326,10 @@ export default function TransactionsPage() {
                         <span
                           className={cn(
                             'tabular-nums',
-                            transaction.type === TypeEnum.income
-                              ? 'text-emerald-600'
-                              : 'text-rose-600',
+                            display.kind === 'income' ? 'text-emerald-600' : 'text-rose-600',
                           )}
                         >
-                          <CurrencyDisplay amount={parseFloat(transaction.amount)} />
+                          <CurrencyDisplay amount={display.amount} />
                         </span>
                       </div>
                     </TableCell>


### PR DESCRIPTION
Stacked on #60. The consolidation arc, stage one: the transactions page and all three write dialogs move off the hand-written adapter onto the generated SDK, speaking ledger natively.

## The native vocabulary — `lib/ledger.ts`

| Helper | Role |
|---|---|
| `displayFields()` | one `LedgerTransaction` → what the UI shows; classification from the **category leg's sign** |
| `buildPostings()` | balanced account/category pair for simple categorised entry — zero-sum by construction |
| `resolveDefaultAccountId()` | entry account, created on first use |
| `useInvalidateLedger()` | invalidates the SDK's array keys **and** the adapter's synthetic legacy keys still used by unmigrated pages |

## What changed in behaviour (all improvements)

- **One fewer request on the page**: category names arrive inline on `posting_lines`, no separate categories fetch
- **Transfers detected structurally** (no category leg) instead of a memo regex
- **`/me` round-trip removed** from create — the old client fetched the user only to send an id the API ignored
- Save buttons get an in-flight disabled state

## Found by the e2e suite, again

The import spec failed after migration: the import dialog invalidated through the adapter's key matcher, which only understood string keys — the generated hooks use array keys. `useInvalidateLedger` covers both; the spec went green. Third sprint in a row where Playwright caught what unit tests could not.

Also: react-day-picker 10 (Dependabot) renamed `initialFocus` → `autoFocus` in the one dialog still passing it.

## Remaining adapter consumers

dashboard, overview, budget-progress, budget page, category page, rules — they migrate next; the adapter dies with them, then the legacy endpoints at `v1.0.0` per the ADR.

## Verification

lint / 47 unit / `tsc` clean; **all 4 Playwright specs green** against the rebuilt stack — the smoke spec now exercises the native write path end to end.