### PR TITLE
docs: catch every document up with the monorepo, workspaces, and SDKs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,13 +76,17 @@ User
 `+10.00` against the Food category. A transfer is two *account* postings and no
 category, tied together by `transfer_group`.
 
-This is enforced in two places, which is worth knowing:
+This is enforced in three places, which is worth knowing:
 
 - `LedgerPosting` has a database `CheckConstraint`
   (`ledger_posting_exactly_one_target`) guaranteeing each posting references an
   account **or** a category, never both and never neither.
-- The zero-sum rule is enforced in the serializer
-  (`finance_serializers._validate_postings`), not in the database.
+- The zero-sum rule is validated in the serializer
+  (`finance_serializers._validate_postings`) so API callers get a clean 400.
+- The zero-sum rule is *also* enforced in the database by a deferred
+  constraint trigger (migration `0006`): at commit time, any transaction whose
+  postings do not sum to zero aborts. Bulk paths, imports, and future bugs
+  cannot corrupt the ledger even if they bypass the serializer.
 
 Business logic lives in `apps/api/pft/finance_services.py`: balances and net worth,
 cash flow, spending trends, envelope snapshots, the rules engine, schedule
@@ -96,15 +100,12 @@ Both are live and routed at the same time. On signup, `pft/signals.py` seeds
 "Cash" account, two category groups and ten `CategoryV2` rows. Nothing keeps
 them in sync afterwards.
 
-The web app reads through the legacy shapes but **writes to the finance API**.
-That translation lives in one file, `apps/web/app/client/pft/v1/v1.ts`: it resolves
-the default budget file and account, maps a `LedgerTransaction` and its postings
-back into a flat `Transaction`, and splits a flat write back into balanced
-postings.
-
-That file is hand-written and lives next to — not inside — `apps/web/app/client/gen/`,
-which is orval's output directory. Do not run `pnpm orval` expecting it to
-produce this; it will overwrite it with something that does not compile.
+The web app talks to the finance API **directly**. The generated orval client
+in `apps/web/app/client/gen/` (tracked in git, regenerated with `pnpm orval`,
+guarded by a CI diff gate) provides the typed calls, and
+`apps/web/app/lib/ledger.ts` supplies the small amount of domain vocabulary on
+top: building balanced postings from form input, display helpers, and SWR
+invalidation. The old read-legacy/write-finance adapter is gone.
 
 ### Where this is going
 
@@ -120,10 +121,10 @@ Link: </api/v1/finance/>; rel="successor-version"
 Warning: 299 - "This endpoint is deprecated and will be removed in v1.0.0..."
 ```
 
-The remaining steps, not yet done:
+The remaining steps:
 
-1. Move the UI onto `/api/v1/finance/*` directly, removing the adapter in
-   `apps/web/app/client/pft/v1/v1.ts`.
+1. ~~Move the UI onto `/api/v1/finance/*` directly~~ — done; the adapter is
+   deleted and the UI runs on the generated client.
 2. Remove the legacy endpoints and models in `v1.0.0`.
 3. Rename `CategoryV2` and `CategoryGroupV2` — the "V2" suffix is an accident of
    history that is currently baked into the public schema.
@@ -146,25 +147,41 @@ Request
       → finance_services.*         ← business logic
 ```
 
-### Tenant scoping is per-viewset, and that is the risk
+## Workspaces (organizations)
 
-`UserScopedModelViewSet` only sets `permission_classes = [IsAuthenticated]`.
-Despite the name, **it does not scope anything.** Every viewset is responsible
-for filtering its own queryset:
+A `BudgetFile` is owned either by a single user (`organization` is NULL — the
+personal case) or by an `Organization`. Membership carries a role:
+
+| Role | Can |
+|---|---|
+| `viewer` | read everything in the workspace |
+| `member` | read and write finance data |
+| `admin` | member + manage members and invitations |
+| `owner` | admin + delete the workspace |
+
+`Invitation` rows let admins invite by email; accepting creates a
+`Membership`. Manager-visible activity is recorded via `pft/audit.py` and
+served read-only (with CSV export) at `/api/v1/audit-log/`.
+
+### Tenant scoping: one Q object, used everywhere
+
+All finance querysets are scoped through `pft/tenancy.py`:
 
 ```python
-# /api/v1/*        - the user owns the row directly
-Transaction.objects.filter(user=self.request.user)
+# read access: personal files + files in any org you belong to
+Account.objects.filter(budget_file_q(request.user))
 
-# /api/v1/finance/* - ownership is reached through the budget file
-Account.objects.filter(budget_file__user=self.request.user)
-LedgerPosting.objects.filter(transaction__budget_file__user=self.request.user)
-EnvelopeAssignment.objects.filter(budget_month__budget_file__user=self.request.user)
+# write access: viewer role is excluded
+LedgerTransaction.objects.filter(budget_file_q(request.user, write=True))
+
+# BudgetFile itself uses prefix="pk"
+BudgetFile.objects.filter(budget_file_q(request.user, prefix="pk"))
 ```
 
 `LedgerPosting`, `LedgerTransactionTag`, `EnvelopeAssignment` and
-`TransactionEvent` have **no user column at all** — they rely entirely on that
-FK chain. One missing filter is a cross-tenant leak.
+`TransactionEvent` have **no user column at all** — they rely entirely on the
+FK chain to the budget file. One missing filter is a cross-tenant leak, and the
+base viewset gates writes so a `viewer` is read-only across the board.
 
 Filtering the queryset is also not sufficient on its own. Any field that
 accepts an ID from the request body must be ownership-checked, or a user can
@@ -186,20 +203,19 @@ apps/web/app/
 ├── client/
 │   ├── httpPFTClient.ts  axios instance, auth header, 401 refresh-and-retry,
 │   │                     error toasts, offline mutation queue
-│   ├── pft/              hand-maintained API client (see above)
-│   └── gen/              orval output - generated, gitignored
-├── lib/                  auth (JWT cookies), finance-client, dates, analytics
+│   └── gen/              orval output — generated, TRACKED in git, guarded by
+│                         a CI regen-diff gate
+├── lib/                  auth (JWT cookies), ledger.ts (posting builders, SWR
+│                         invalidation), finance-client (thin helpers), backup,
+│                         import/export, dates, analytics
+├── e2e/  (../e2e)        Playwright suite — runs against the real stack in CI
 ├── hooks/                Zustand stores
-└── context/              currency provider
+└── context/              currency + organization providers
 ```
 
 Data fetching is SWR keyed on URL-ish strings. Note that global revalidation is
 switched off in `main.tsx`, so data refreshes on explicit mutation rather than
 on focus or reconnect.
-
-`apps/web/app/lib/finance-client.ts` is a *second* hand-written client used by the
-reports and rules pages. It duplicates helpers from `client/pft/v1/v1.ts`,
-including a separate budget-file cache. Merging the two is a good contribution.
 
 ## Authentication
 
@@ -240,9 +256,36 @@ Migrations are not reversible: the data migrations have no-op reverse functions.
 apps/api/pft/tests/
 ├── test_api_smoke.py         registration, JWT, CRUD, filtering, pagination
 ├── test_api_finance_v1.py    ledger, envelopes, reports, import/export, backups
+├── test_ledger_invariants.py zero-sum DB trigger, Hypothesis property tests
+├── test_ledger_filtering.py  server-side search / ordering / pagination
 ├── test_tenant_isolation.py  user B cannot read or write user A's data
-└── test_auth_hardening.py    logout, token revocation, throttling
+├── test_organizations.py     workspaces, roles, invitations
+├── test_audit_log.py         audit recording and manager-only access
+├── test_auth_hardening.py    logout, token revocation, throttling
+└── test_account_deletion.py  account deletion cascades
 ```
 
-There is no frontend test harness yet. Adding vitest plus one Playwright smoke
-path is a genuinely valuable contribution.
+The frontend has vitest units (`apps/web/**/*.test.ts`) and a Playwright
+end-to-end suite (`apps/web/e2e/`) that drives the real Docker stack through
+nginx — login, transactions, budgets, import, backup/restore, and a two-browser
+shared-workspace scenario. Both run in CI.
+
+## Monorepo and SDKs
+
+```
+apps/       api, web, landing — deployables
+packages/   sdk-ts (@fintrack/sdk on npm), sdk-py (fintrack-sdk on PyPI)
+```
+
+The OpenAPI schema is the contract between all of them:
+
+```
+drf-spectacular  ──▶  apps/web/schema/pft.yaml  ──▶  orval ──▶ apps/web/app/client/gen/
+                                                 ──▶  orval ──▶ packages/sdk-ts/src/gen/
+                                                 ──▶  openapi-python-client ──▶ packages/sdk-py/
+```
+
+CI enforces three lockstep gates: the committed schema matches the backend
+(schema-sync), the web client matches the schema (orval regen diff), and the
+Python SDK matches schema + generation + `post_generate.py` patch. Change the
+API and CI tells you exactly which artifacts to regenerate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,22 +13,25 @@ merged pull request without guessing.
 ## Repository layout
 
 ```
-api/        Django + DRF backend (uv, Python 3.12+)
-web/        React 19 + Vite single-page app (pnpm)
-landing/    Next.js marketing site (pnpm) - independent of the app
-docs/       Feature audit artifacts
-scripts/    Repo tooling
+apps/api/         Django + DRF backend (uv, Python 3.12+)
+apps/web/         React 19 + Vite single-page app (pnpm)
+apps/landing/     Next.js marketing site (pnpm) - independent of the app
+packages/sdk-ts/  @fintrack/sdk - generated TypeScript client (npm)
+packages/sdk-py/  fintrack-sdk - generated Python client (PyPI)
+docs/             Self-hosting guide, ADRs, blog, feature audit artifacts
+scripts/          Repo tooling
 ```
 
 The backend has two API surfaces that both exist today:
 
-- `/api/v1/*` - the original flat `Transaction`/`Category`/`Budget` model.
+- `/api/v1/*` - auth, profile, workspaces, audit log, plus the deprecated flat
+  `Transaction`/`Category`/`Budget` model (removal planned for `v1.0.0`).
 - `/api/v1/finance/*` - a double-entry ledger with envelope budgeting, rules,
   scheduled transactions, reports, imports, exports and backups.
 
-The web app reads through the legacy shapes but writes to the finance API, via the
-hand-maintained adapter in `apps/web/app/client/pft/`. Consolidating these is the
-biggest open piece of work.
+The web app talks to the finance API directly through the generated client in
+`apps/web/app/client/gen/`. New features belong on the finance surface; the
+legacy endpoints are maintained, not extended.
 
 ## Getting set up
 
@@ -106,14 +109,41 @@ for why.
   side-effect imports that matter.
 - **TypeScript** follows the ESLint flat config in `apps/web/eslint.config.js`. Avoid
   `any`; if you truly need it, explain why in a comment.
-- Do not commit generated API clients into `apps/web/app/client/gen/` - that directory
-  is orval's output and is ignored. The maintained client lives in
-  `apps/web/app/client/pft/`.
+- `apps/web/app/client/gen/` is orval's output and **is tracked in git** - never
+  edit it by hand; regenerate it instead (see below). CI fails if it drifts
+  from the schema.
+
+## If you change the API
+
+The OpenAPI schema is the contract, and CI keeps every consumer in lockstep.
+After changing serializers, views, or routes:
+
+```bash
+cd apps/api && uv run manage.py spectacular --file ../web/schema/pft.yaml   # 1. schema
+```
+
+```bash
+cd apps/web && pnpm orval                                                   # 2. web client
+```
+
+```bash
+cd packages/sdk-ts && pnpm run generate && pnpm run build                   # 3. TS SDK
+```
+
+```bash
+cd packages/sdk-py && uvx openapi-python-client generate \
+  --path ../../apps/web/schema/pft.yaml --output-path fintrack_sdk \
+  --meta none --overwrite && python3 post_generate.py                       # 4. Python SDK
+```
+
+Commit the regenerated artifacts with your change - CI diff gates enforce all
+four.
 
 ## Testing expectations
 
-- Backend changes need tests. `apps/api/pft/tests/` has three suites: smoke, finance,
-  and tenant isolation.
+- Backend changes need tests. `apps/api/pft/tests/` has suites for API smoke,
+  the finance domain, ledger invariants, filtering, tenant isolation,
+  organizations, the audit log, auth hardening, and account deletion.
 - **Anything that touches a queryset, serializer or permission must have a
   cross-tenant test** in `apps/api/pft/tests/test_tenant_isolation.py`. This is a
   multi-user finance app; "user B cannot see or change user A's data" is the
@@ -128,13 +158,13 @@ for why.
 Look for the `good first issue` label. If none are open and you want somewhere to
 start, these are all real and self-contained:
 
-- Remove the ~21 unused shadcn components from `apps/web/app/components/ui/`.
-- Move transaction filtering and sorting server-side; today they run over the
-  current page only, so the result count is wrong.
-- Replace the hand-rolled currency formatting in
-  `apps/web/app/components/ui/currency-display.tsx` with
-  `Intl.NumberFormat(locale, { style: 'currency' })`, including the chart tooltips.
-- Register the finance models in `apps/api/pft/admin.py`.
-- Surface envelope budgeting in the UI: `BudgetMonth` and `EnvelopeAssignment`
-  with goals and carryover are fully implemented in the API.
-- Add a backup/restore screen for `/api/v1/finance/backups/`.
+- Audit `apps/web/app/components/ui/` for shadcn components nothing imports and
+  remove them.
+- Build an audit-log viewer UI for `/api/v1/audit-log/` (the API is done,
+  including CSV export; managers currently have no screen for it).
+- Rename `CategoryV2`/`CategoryGroupV2` (schema + models + regenerated
+  clients) before `v1.0.0` bakes the names in.
+- Merge `apps/web/app/lib/finance-client.ts`'s remaining helpers into the
+  generated client + `lib/ledger.ts` and delete it.
+- Move the access token out of JavaScript-readable cookies (HttpOnly refresh
+  cookie + in-memory access token) - see SECURITY.md's known limitations.

--- a/README.md
+++ b/README.md
@@ -35,19 +35,21 @@ no subscriptions, no third-party services, no vendor lock-in.
 - 📅 **Flexible views** — browse transactions by day, week, or month
 - 🔁 **Scheduled transactions and rules** for recurring activity
 - 📈 **Reports** on spending, budgets, and trends
-- 📦 **Import / export** your data (CSV, JSON) plus encrypted backup bundles
+- 📦 **Import / export** your data (CSV, OFX, QIF, YNAB and more in; CSV, JSON, XLSX out) plus encrypted backup & restore from the UI
 - 🔒 **100% self-hosted** — your data never leaves your server
-- 👤 **Multi-user support** (optional)
+- 👥 **Shared workspaces** — organizations with owner / admin / member / viewer roles, invitations, and a manager-visible audit log
 - 🌗 **Light / dark mode** with a responsive UI for mobile and desktop
-- 🔌 **API-first architecture** with OpenAPI docs out of the box
+- 🔌 **API-first architecture** with OpenAPI docs, plus official [TypeScript](packages/sdk-ts) and [Python](packages/sdk-py) SDKs
 
 ## 🛠️ Tech stack
 
 | Layer | Technology |
 | --- | --- |
-| Frontend | [React 19](https://react.dev/), [Vite](https://vitejs.dev/), [TailwindCSS](https://tailwindcss.com/), [Zustand](https://zustand-demo.pmnd.rs/), [pnpm](https://pnpm.io/) |
+| Frontend | [React 19](https://react.dev/), [Vite](https://vitejs.dev/), [TailwindCSS](https://tailwindcss.com/), [SWR](https://swr.vercel.app/), [pnpm](https://pnpm.io/) |
 | Backend | [Django 5](https://www.djangoproject.com/) + [Django REST Framework](https://www.django-rest-framework.org/), JWT auth, [uv](https://docs.astral.sh/uv/) |
+| Background jobs | [Celery](https://docs.celeryq.dev/) + [Redis](https://redis.io/) (imports/exports; falls back to inline without a broker) |
 | Database | [PostgreSQL](https://www.postgresql.org/) |
+| SDKs | [`@fintrack/sdk`](packages/sdk-ts) (TypeScript) and [`fintrack-sdk`](packages/sdk-py) (Python), generated from the OpenAPI schema |
 | Infrastructure | Docker & Docker Compose, hot reload in development |
 
 ## 🚀 Quick Start
@@ -70,12 +72,9 @@ images, and starts every service. Once it finishes, open:
 | API docs (Swagger UI) | http://localhost:8000/api/docs/ |
 | API docs (ReDoc) | http://localhost:8000/api/redoc/ |
 
-Log in with the default admin account — **change these credentials immediately**:
-
-```
-email:    admin@example.com
-password: fintrack
-```
+There is no default account — register through the UI; the first account you
+create is yours. (For a Django admin user, see
+[docs/self-hosting.md](docs/self-hosting.md#creating-your-account).)
 
 Other lifecycle commands:
 
@@ -124,17 +123,23 @@ more details on each service.
 
 ```
 fintrack/
-├── apps/api/            # Django backend (DRF, JWT auth, OpenAPI schema)
-│   ├── app/        # Django project settings
-│   └── pft/        # Main Django app (finance domain)
-├── apps/web/            # React frontend (Vite, TailwindCSS, Zustand)
-│   ├── app/        # Application source
-│   └── schema/     # Generated API schema / client
-├── docs/           # Project documentation and feature audits
-├── scripts/        # Maintenance and audit scripts
+├── apps/
+│   ├── api/            # Django backend (DRF, JWT auth, OpenAPI schema)
+│   │   ├── app/        # Django project settings
+│   │   └── pft/        # Main Django app (finance domain)
+│   ├── web/            # React frontend (Vite, TailwindCSS, SWR)
+│   │   ├── app/        # Application source (client/gen/ is the orval client)
+│   │   ├── e2e/        # Playwright end-to-end suite
+│   │   └── schema/     # OpenAPI schema (pft.yaml), kept in sync by CI
+│   └── landing/        # Next.js marketing site (not part of the self-hosted stack)
+├── packages/
+│   ├── sdk-ts/         # @fintrack/sdk — TypeScript client (npm)
+│   └── sdk-py/         # fintrack-sdk — Python client (PyPI)
+├── docs/               # Self-hosting guide, ADRs, blog, feature audits
+├── scripts/            # Maintenance and audit scripts
 ├── docker-compose.yml
-├── setup.sh        # One-command setup for self-hosting
-└── Makefile        # Common development tasks
+├── setup.sh            # One-command setup for self-hosting
+└── Makefile            # Common development tasks
 ```
 
 ## ⚙️ Configuration
@@ -165,6 +170,16 @@ make test-api        # API smoke tests
 make test-api-all    # full API test suite
 ```
 
+Frontend units and end-to-end tests:
+
+```bash
+cd apps/web && pnpm run test              # vitest units
+```
+
+```bash
+docker compose up -d && cd apps/web && pnpm exec playwright test   # e2e against the real stack
+```
+
 Missing `.env` files are created automatically (via `./setup.sh configure`)
 before any Docker-based target runs — no separate bootstrap step is needed.
 
@@ -174,12 +189,27 @@ FinTrack is API-first. Interactive documentation is served by the backend at
 [/api/docs/](http://localhost:8000/api/docs/) (Swagger UI) and
 [/api/redoc/](http://localhost:8000/api/redoc/) (ReDoc).
 
-- `/api/v1/*` — core auth, profile, and compatibility endpoints
+- `/api/v1/*` — auth, profile, workspaces (`orgs`), and the manager-only `audit-log`
 - `/api/v1/finance/*` — the finance domain:
   - `budget-files`, `accounts`, `category-groups`, `categories`, `payees`, `tags`
   - `transactions`, `postings`, `scheduled-transactions`, `rules`
   - `budget-months`, `envelope-assignments`, `reports`
   - `exports`, `imports`, `backups`
+
+### Official SDKs
+
+```bash
+npm install @fintrack/sdk        # TypeScript — plain fetch, zero runtime deps
+```
+
+```bash
+pip install fintrack-sdk         # Python — sync + asyncio variants per operation
+```
+
+Both are generated from the committed OpenAPI schema
+([`apps/web/schema/pft.yaml`](apps/web/schema/pft.yaml)), which CI keeps in
+lockstep with the backend. See [packages/sdk-ts](packages/sdk-ts) and
+[packages/sdk-py](packages/sdk-py) for usage.
 
 ## 🗺️ Roadmap
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,20 @@ These are real and tracked, not hidden:
   database as plaintext, as do completed exports. Run
   `manage.py prune_finance_jobs` periodically; see
   [docs/self-hosting.md](docs/self-hosting.md).
-- **The finance endpoints are unpaginated**, so a large ledger returns in one
+- **Most finance list endpoints are unpaginated** (transactions are the
+  exception), so a large ledger's accounts, categories, or payees return in one
   response.
+
+## Workspaces and roles
+
+Budget files can be shared through organizations. Roles are enforced
+server-side: `viewer` is read-only everywhere, `member` can write finance
+data, `admin` manages members and invitations, `owner` can delete the
+workspace. Workspace activity is recorded to an audit log that only owners and
+admins can read (`/api/v1/audit-log/`, with CSV export). Tenant scoping is
+centralised in `apps/api/pft/tenancy.py` and covered by
+`test_tenant_isolation.py` and `test_organizations.py` — any change to a
+queryset, serializer, or permission needs a test there.
 
 ## History
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,129 +1,69 @@
-# 🚀 Backend API
+# FinTrack API
 
-A DRF designed with developer productivity and best practices in mind.
+Django 5 + Django REST Framework backend: JWT auth (SimpleJWT), a double-entry
+ledger with envelope budgeting, shared workspaces with roles, imports/exports
+on Celery, and an OpenAPI schema that drives every generated client.
 
-## 🧩 Features
+For how the system fits together, read [ARCHITECTURE.md](../../ARCHITECTURE.md).
+For contribution workflow, read [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-- ✅ Django 5.x with modular settings
-- ✅ PostgreSQL as default database
-- ✅ DRF (Django REST Framework) for API development
-- ✅ OpenAPI documentation using drf-spectacular
-- ✅ Psycopg 3 integration (PostgreSQL adapter)
-- ✅ Ruff for linting and formatting
-- ✅ Pre-commit hook to enforce code style
-- ✅ Task automation via Makefile
-- ✅ Docker support (uv-based image, optimized build)
-- ✅ VSCode dev container support
+## Run it
 
----
-
-## 🛠 Getting Started
-
-### Option 1: Using Docker
-
-1. Copy and rename `.env.example` to `.env.dev`
-2. Run Docker:
+From the repo root, the full stack:
 
 ```bash
-docker compose build
-docker compose run migrate
-docker compose up
+./setup.sh start
 ```
 
-Django will be available at: http://localhost:8000
-
-### Option 2: Using Makefile
-
-1. Copy and rename `.env.example` to `.env.dev`
-2. Sync and install dependencies:
+Or just the backend, locally:
 
 ```bash
-make install
+cp .env.example .env    # point DATABASE_HOST at your Postgres
+uv sync
+uv run manage.py migrate
+uv run manage.py runserver
 ```
 
-3. Run migrations and dev server:
+`uv` is the only supported toolchain; `uv.lock` is authoritative.
+
+## Layout
+
+```
+app/                Django project: settings (base/dev/prod), urls, celery
+pft/                the finance domain
+├── models.py       User, Organization, BudgetFile, the ledger models
+├── tenancy.py      budget_file_q() — every queryset is scoped through this
+├── finance_views.py / finance_serializers.py / finance_services.py
+├── org_views.py    workspaces, members, invitations
+├── audit.py        audit_views.py — manager-only audit log
+├── tasks.py        Celery tasks (imports, exports)
+└── tests/          nine suites; tenant isolation is the one that matters most
+```
+
+## Development
 
 ```bash
-make migrate
-make run
+uv run ruff check .                 # lint
+uv run manage.py test               # tests
+uv run manage.py makemigrations     # after model changes
+uv run manage.py spectacular --file ../web/schema/pft.yaml   # after API changes
 ```
 
----
+The schema command matters: CI fails if the committed schema, the web client,
+or either SDK drifts from the backend. See "If you change the API" in
+CONTRIBUTING.md.
 
-## 🧪 Development
-
-### Available Makefile Commands
-
-⚠️ Warning
-
-Makefile commands only work on your local development machine, when DATABASE_HOST is set to localhost.
-For development inside Docker, execute commands using:
-docker compose exec web {your command}
+Useful management commands:
 
 ```bash
-make install        # Sync dependencies with uv
-make run            # Start development server
-make migrate        # Apply database migrations
-make shell          # Open Django shell_plus
-make test           # Run tests
-make lint           # Run Ruff linter
-make format         # Format code using Ruff
-make clean          # Delete cache and temporary files
-make superuser name # Make super user
-make app name={app_name} # Create app
-make command app={app_name} command={command_name} # Create command with app name and command name
+uv run manage.py seed_demo             # demo user with six months of data
+uv run manage.py prune_finance_jobs    # clear old import/export payloads
 ```
 
----
+## API docs
 
-## ✅ Linting
+Served by the running backend:
 
-We use [Ruff](https://docs.astral.sh/ruff/) for linting and formatting.
-
-Configure rules inside `pyproject.toml` under `[tool.ruff]`, `[tool.ruff.lint]`, and `[tool.ruff.format]`.
-
-To run manually:
-
-```bash
-make lint
-make format
-```
-
----
-
-## 🔄 Pre-commit Hook
-
-Set up the pre-commit hook for consistent code quality:
-
-```bash
-pre-commit install
-```
-
-It will run Ruff check, formatting and GitLeaks inspection before every commit.
-
----
-
-## 📦 Docker
-
-The Dockerfile is based on `ghcr.io/astral-sh/uv` with pre-installed uv support. It:
-
-- Installs dependencies using uv
-- Waits for PostgreSQL using `wait-for-it.sh`
-- Runs migrations
-- Starts Django development server
-
-Example `docker-compose.yml` connects the Django app to a PostgreSQL container.
-
----
-
-## 📚 API Docs
-
-OpenAPI documentation is powered by `drf-spectacular`:
-
-- `/api/schema/` – schema endpoint
-- `/api/docs/` – Swagger UI
-
----
-
-Purely inspired from
-https://github.com/saba-ab/advanced_django_blueprint
+- `/api/schema/` — the OpenAPI document
+- `/api/docs/` — Swagger UI
+- `/api/redoc/` — ReDoc

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,53 +1,54 @@
-# Frontend
+# FinTrack Web
 
-## Screenshot
-![Screenshot 2025-04-17 at 12 05 51 PM](https://github.com/user-attachments/assets/67519e75-19b0-44f8-abe1-d5c57f8a710d)
+React 19 single-page app: Vite, TailwindCSS + shadcn/ui, SWR for data, and a
+generated (orval) API client. Served by nginx in the Docker stack, which also
+proxies `/api/` to the backend.
 
+For how the system fits together, read [ARCHITECTURE.md](../../ARCHITECTURE.md).
 
-## Getting Started
+## Run it
 
-### 1. Project Setup Framework Boilerplate (Vite)
+```bash
+cp .env.example .env      # VITE_BASE_DOMAIN, default http://localhost:8000
+pnpm install
+pnpm dev                  # :5173, expects the API running
+```
 
-Folder Structure (components/, pages/, assets/, hooks/, utils/)
+pnpm's version is pinned by `packageManager`; `corepack enable` once and forget.
 
-Basic Routing (React Router)
+## Layout
 
-State Management Ready (Zustand)
+```
+app/
+├── pages/                one directory per route
+├── components/           feature components (ui/ = shadcn primitives)
+├── client/
+│   ├── httpPFTClient.ts  axios: auth header, 401 refresh-and-retry, toasts
+│   └── gen/              orval output — tracked in git, never hand-edited
+├── lib/                  ledger.ts (posting builders, SWR invalidation),
+│                         auth, backup, import/export, dates
+├── context/              currency + organization providers
+└── hooks/                Zustand stores
+e2e/                      Playwright suite (runs against the Docker stack)
+schema/pft.yaml           OpenAPI schema — the contract with the backend
+```
 
-pnpm
+## Development
 
-### Styling Setup
-Tailwind CSS, Dark Mode Toggle
+```bash
+pnpm run lint             # eslint
+pnpm run test             # vitest units
+pnpm run build            # tsc -b && vite build
+pnpm orval                # regenerate app/client/gen/ after schema changes
+```
 
-### Components
-Navbar
+End-to-end tests need the real stack:
 
-Sidebar
+```bash
+docker compose up -d
+pnpm exec playwright install chromium
+pnpm exec playwright test
+```
 
-Button, Input, Modal, Toast
-
-Loading Spinner / Skeleton
-
-Error & Empty States
-
-### Auth Placeholder
-Login / Signup UI
-
-Mock auth logic or placeholder for future integration
-
-### API Integration Setup
-Axios / Fetch Wrapper
-
-.env.example config support
-
-### Dev Tools
-Linting (ESLint + Prettier)
-
-Git with .gitignore
-
-## Bonus Extras
-Mobile Responsive layout
-
-Dark/Light theme switcher
-
-Icon library (lucide-react)
+CI runs all of the above, plus a diff gate that fails if `app/client/gen/`
+does not match `schema/pft.yaml`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -69,7 +69,7 @@ server {
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Imports and exports are computed synchronously.
+        # Import previews parse synchronously; give large files headroom.
         proxy_read_timeout 300s;
         client_max_body_size 20m;
     }
@@ -168,9 +168,13 @@ different signing key invalidates every session and token.
 
 ### Application-level backups
 
-The API also has an encrypted backup bundle endpoint
-(`/api/v1/finance/backups/`), which stores a client-encrypted archive. It is
-not yet exposed in the UI, and it is not a substitute for a database dump.
+Settings → Backup in the UI creates an encrypted backup bundle
+(`/api/v1/finance/backups/`): the archive is encrypted in the browser
+(AES-GCM, key derived from your passphrase) before upload, and restore replays
+it through the public API. It covers one budget file's finance data — useful
+for moving between instances — but it is not a substitute for a database dump,
+which is the only thing that captures users, workspaces, and every file at
+once.
 
 ## Upgrading
 


### PR DESCRIPTION
The docs lagged several arcs behind the code. Worst offender: the README still told people to log in as \`admin@example.com\` / \`fintrack\` — an account that no longer exists (and whose removal was a security fix).

- **README** — monorepo tree (\`apps/\` + \`packages/\`), SDK install/use section, workspaces + audit log in features, SWR/Celery/SDKs in the stack table, register-your-own-account quickstart, web unit + Playwright testing section
- **ARCHITECTURE** — frontend now on the generated client (adapter deleted), zero-sum invariant enforced by the DB trigger, organizations/roles and \`tenancy.py\` scoping, audit log, monorepo + schema→clients generation pipeline with the three CI lockstep gates, current test-suite inventory
- **CONTRIBUTING** — real layout, "If you change the API" regen workflow (schema → web client → both SDKs), updated testing expectations, good-first-issue list refreshed (five of six were already done)
- **SECURITY** — workspaces/roles/audit-log section, corrected the pagination limitation
- **docs/self-hosting** — backup/restore is now in the UI (client-side AES-GCM), imports no longer synchronous
- **apps/api/README, apps/web/README** — rewritten from upstream-template leftovers ("Mock auth logic") into real service docs

Docs only; no code changes.