### PR TITLE
fix: tell login failures apart; small web env/docker hygiene

### DIFF
--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .git
+.env
 .env.*
 !.env.example
 *.log

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,7 @@
 # Base URL of the FinTrack API. Leave unset to call the same origin the UI is
 # served from (which is what the Docker setup does, via the nginx /api proxy).
-VITE_BASE_DOMAIN=http://localhost:8000
+# Only set this for local `pnpm dev` against a separately running API:
+# VITE_BASE_DOMAIN=http://localhost:8000
 
 # Optional analytics. Both must be set for any script to load; leaving them empty
 # means this build reports to nobody.

--- a/apps/web/app/lib/auth.ts
+++ b/apps/web/app/lib/auth.ts
@@ -66,14 +66,36 @@ export function removeTokens() {
   removeCookie(TOKEN_EXPIRY_KEY)
 }
 
+export type LoginErrorKind = 'invalid' | 'server' | 'network'
+
+export class LoginError extends Error {
+  kind: LoginErrorKind
+
+  constructor(kind: LoginErrorKind, message: string) {
+    super(message)
+    this.name = 'LoginError'
+    this.kind = kind
+  }
+}
+
 export async function login(email: string, password: string) {
-  const response = await fetch(`${PFT_BASE_URL}/api/token/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
-  })
+  let response: Response
+  try {
+    response = await fetch(`${PFT_BASE_URL}/api/token/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+  } catch {
+    // fetch itself only throws on network-level failures (server down, DNS,
+    // CORS/CSP blocked) - never on HTTP error statuses.
+    throw new LoginError('network', 'Could not reach the server')
+  }
+  if (response.status === 400 || response.status === 401) {
+    throw new LoginError('invalid', 'Invalid credentials')
+  }
   if (!response.ok) {
-    throw new Error('Invalid credentials')
+    throw new LoginError('server', `Server error (${response.status})`)
   }
   const data = await response.json()
   setTokens(data.access, data.refresh)

--- a/apps/web/app/pages/login/index.tsx
+++ b/apps/web/app/pages/login/index.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Link } from 'react-router-dom'
-import { login } from '@/lib/auth'
+import { login, LoginError } from '@/lib/auth'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -22,9 +22,14 @@ export function LoginPage() {
     try {
       await login(email, password)
       navigate('/home')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      setError('Invalid credentials')
+    } catch (err) {
+      if (err instanceof LoginError && err.kind === 'invalid') {
+        setError('Invalid credentials')
+      } else if (err instanceof LoginError && err.kind === 'network') {
+        setError('Cannot reach the server — is the API running and reachable?')
+      } else {
+        setError('Something went wrong on the server. Please try again.')
+      }
       console.error(err)
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
Prompted by a real first-run session that ended at a bare "Invalid credentials" when the API was actually unreachable.

- `lib/auth.ts` throws a typed `LoginError` with three kinds — `invalid` (400/401), `server` (other non-OK, message carries the status), `network` (fetch threw: API down/DNS/CORS). The login page shows a distinct message per kind, so a stopped API container no longer reads as a wrong password.
- `apps/web/.dockerignore` excludes `.env`.
- `VITE_BASE_DOMAIN` commented out in the web example env — Docker builds default to the same-origin nginx `/api` proxy.

Web lint clean, 52 unit tests green.

Note: the working tree also had changes pre-filling default admin credentials in `.env.example` (+ matching README/SECURITY/self-hosting text). Held out of this PR — see conversation.