### PR TITLE
docs: clarify first-account registration in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,15 @@ images, and starts every service. Once it finishes, open:
 | API docs (Swagger UI) | http://localhost:8000/api/docs/ |
 | API docs (ReDoc) | http://localhost:8000/api/redoc/ |
 
-There is no default account — register through the UI; the first account you
-create is yours. (For a Django admin user, see
-[docs/self-hosting.md](docs/self-hosting.md#creating-your-account).)
+There is no default account. To get started:
+
+1. Open http://localhost:5173/register
+2. Create your account with an email and password
+3. Log in with those credentials
+
+The first account you create is yours — there are no pre-seeded users.
+For a Django admin (superuser) account, see
+[docs/self-hosting.md](docs/self-hosting.md#creating-your-account).
 
 Other lifecycle commands:
 


### PR DESCRIPTION
## Summary

New users may expect pre-seeded credentials (e.g. `admin@example.com` / `fintrack`) and hit confusing 401 / "Invalid credentials" errors when they try to log in.

This PR expands the Quick Start section with explicit numbered steps showing how to register the first account via the web UI at `/register`.

## Changes

- Replaced the single-line note about registration with a clear numbered list:
  1. Open http://localhost:5173/register
  2. Create your account with an email and password
  3. Log in with those credentials
- Added a note that there are no pre-seeded users
- Kept the pointer to `docs/self-hosting.md` for superuser creation