### PR TITLE
fix: skip redundant uv sync on every container boot

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,6 +26,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/app/.venv/bin:$PATH"
 
+# uv run implicitly re-syncs the venv before every invocation, using uv's
+# default groups - which include "dev" (ruff, hypothesis, pre-commit) even
+# though the venv above was built with --no-dev. Left unset, every uv run in
+# entrypoint.sh/entrypoint.migrate.sh/docker-compose's worker&beat commands
+# would redownload and reinstall the dev group from scratch on each container
+# boot. The venv above is already exactly what --frozen --no-dev produces, so
+# skip that resync. docker-compose.dev.yml resets this to 0, since its bind
+# mount shadows this venv and `make dev` needs uv to sync one back into place.
+ENV UV_NO_SYNC=1
+
 EXPOSE 8000
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,11 @@
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 #
 # or simply `make dev`.
+#
+# The bind mounts below shadow the .venv that apps/api/Dockerfile builds into
+# /app, so these services need `uv run` to sync a venv from scratch on first
+# run instead of skipping sync like the prod image does - see UV_NO_SYNC in
+# apps/api/Dockerfile.
 
 services:
   api:
@@ -10,6 +15,7 @@ services:
       DJANGO_SETTINGS_MODULE: app.settings.dev
       DJANGO_ENV: development
       DEBUG: "True"
+      UV_NO_SYNC: "0"
     volumes:
       - ./apps/api:/app
       - api_run:/app/run
@@ -19,6 +25,7 @@ services:
       DJANGO_SETTINGS_MODULE: app.settings.dev
       DJANGO_ENV: development
       DEBUG: "True"
+      UV_NO_SYNC: "0"
     volumes:
       - ./apps/api:/app
       - api_run:/app/run
@@ -28,6 +35,7 @@ services:
       DJANGO_SETTINGS_MODULE: app.settings.dev
       DJANGO_ENV: development
       DEBUG: "True"
+      UV_NO_SYNC: "0"
     volumes:
       - ./apps/api:/app
       - api_run:/app/run
@@ -37,6 +45,7 @@ services:
       DJANGO_SETTINGS_MODULE: app.settings.dev
       DJANGO_ENV: development
       DEBUG: "True"
+      UV_NO_SYNC: "0"
     volumes:
       - ./apps/api:/app
       - api_run:/app/run


### PR DESCRIPTION
## What does this change?

Stops every FinTrack API container (`api`, `migrate`, `worker`, `beat`) from redownloading and reinstalling ~16MB of dev-only Python packages (ruff, hypothesis, virtualenv) on every single boot.

## Why?

`uv run` implicitly re-syncs the venv before each invocation using uv's default dependency groups, which include `dev` — even though the image is built with `--no-dev`. Every entrypoint's `uv run manage.py ...` / `uv run gunicorn ...` / `uv run celery ...` call was triggering a redundant sync that redownloaded and reinstalled the dev group from scratch, wasting ~10-15s and ~16MB of bandwidth on every `docker compose up`, restart, or pod restart — for packages only needed by `make dev`'s local lint/test workflow and never used at runtime.

Fix: `ENV UV_NO_SYNC=1` in the Dockerfile so `uv run` trusts the venv already built at image-build time. `docker-compose.dev.yml` resets it to `0` for api/migrate/worker/beat, since their bind mount shadows that baked-in venv and `make dev` needs uv to sync a fresh one (including dev deps) into place instead.

## How was it verified?

- [x] `cd api && uv run ruff check . && uv run manage.py test` — ruff: all checks passed; tests: 140 passed
- [x] `docker compose build && docker compose up -d` and the app works end to end — api/migrate/worker/beat all boot with zero download/install lines now; api served a healthy `/healthz/`
- [x] Tried it manually: compared `migrate` logs before/after. Before: `Downloading ruff (10.9MiB)`, `hypothesis`, `virtualenv`, `Installed 11 packages`. After: none. Also confirmed `make dev`'s bind-mounted path still works — first run syncs a full venv incl. dev deps from scratch into the bind mount, second run is fast with no re-download.

## Checklist

- [x] No secrets, `.env` files, or generated clients committed

Infra-only change (Dockerfile env var + compose env var) — no queryset/serializer/permission or API surface touched, so the tenant-isolation-test and docs checklist items don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)