### PR TITLE
fix(web): open the Add transaction dialog when already on /transactions

### DIFF
--- a/apps/web/app/pages/transactions/index.tsx
+++ b/apps/web/app/pages/transactions/index.tsx
@@ -93,14 +93,20 @@ export default function TransactionsPage() {
   const [currentPage, setCurrentPage] = useState(1)
   const [debouncedSearch, setDebouncedSearch] = useState('')
 
+  // Also has to run when ?new=1 arrives on a navigation that does not remount
+  // this page. Triggering the palette's action while already on /transactions
+  // only changes the search params, so the initializer above never re-runs and
+  // the dialog would otherwise stay shut. Depends on searchParams for exactly
+  // that case; deleting the param on the way through keeps it idempotent, and
+  // makes the setState a no-op when the initializer already opened the dialog.
   useEffect(() => {
     if (searchParams.get('new') === '1') {
+      setShowAddTransaction(true)
       const next = new URLSearchParams(searchParams)
       next.delete('new')
       setSearchParams(next, { replace: true })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [searchParams, setSearchParams])
 
   // Debounced so typing does not fire a request per keystroke.
   useEffect(() => {


### PR DESCRIPTION
## What does this change?

The command palette's "Add transaction" action does nothing when you are
already on the Transactions page. One line of dependencies on an effect in
`app/pages/transactions/index.tsx` fixes it.

Closes #

## Why?

`command-menu.tsx` implements "Add transaction" by navigating to
`/transactions?new=1`, and the transactions page turned that param into an
open dialog in two places that both run **once per mount**:

- a `useState` lazy initializer reading `searchParams.get('new')`
- a `useEffect(..., [])` that strips the param afterwards

That works when the action comes from another route, because the page mounts
fresh. Triggering it while already on `/transactions` is a *same-route*
navigation — React Router updates the search params without remounting — so
neither runs. The dialog stays shut and `?new=1` is left stranded in the URL,
which is the visible tell that the effect never fired.

The fix gives the effect a real dependency on `searchParams` and has it open
the dialog. The lazy initializer stays, so arriving from another route still
paints the dialog with no render round trip (the reason it was written that
way) and the `setState` is simply a no-op in that path. Deleting the param on
the way through keeps the effect idempotent.

## This is the E2E failure everyone has been seeing

`e2e/keyboard-entry.spec.ts:15` has been catching this the whole time — it
does `page.goto('/transactions')` and *then* uses the palette, which is
exactly the broken path.

It read as flaky rather than broken because of a race in the opposite
direction from what you would guess: when the click lands **before** hydration
completes, it falls back to a full page load, which remounts the page and
therefore does honour `?new=1`. So the suite went green whenever CI was slow
enough and red otherwise. Recent evidence:

| Run | Branch | E2E |
| --- | --- | --- |
| 32938603685 | django-6-upgrade | pass |
| 32955795772 | django-6-upgrade | fail |
| 32917124673 | dependabot i18next | pass |
| 32917101764 | dependabot typescript | fail |
| 32917053890 | dependabot lucide | fail |

Backend-only and frontend-dependency-only branches both hit it, and both also
pass sometimes, which is what kept it looking like infrastructure noise.

## How was it verified?

- [x] `cd apps/web && pnpm run lint && pnpm run build`
- [x] `docker compose build && docker compose up -d` and the app works end to
      end
- [x] Tried it manually (see below)

Against the real docker stack, driving the palette from each starting route
and recording the URL and dialog count:

| Start route | Before | After |
| --- | --- | --- |
| from `/home` | `/transactions`, 1 dialog | `/transactions`, 1 dialog |
| from `/transactions` | `/transactions?new=1`, **0 dialogs** | `/transactions`, **1 dialog** |

The `/home` column is the control — it was already working and is unchanged.

Also green: full Playwright suite 17/17 (previously 16/17 with
`keyboard-entry.spec.ts` failing), web unit tests 69/69, `pnpm run lint`
0 errors, `pnpm run build` succeeds.

## Checklist

- [x] Backend changes to a queryset, serializer or permission come with a
      cross-tenant test — n/a, this is a single frontend file
- [x] No secrets, `.env` files, or generated clients committed
- [x] Docs updated if the setup steps or API surface changed — n/a

## Note for the reviewer

The new `setShowAddTransaction(true)` inside the effect trips
`react-hooks/set-state-in-effect`, taking the file's warning count from 16 to
17. It is a warning, not an error, and `pnpm run lint` stays green. Consuming
a URL param into local state is the ordinary React Router shape for this, and
the rule already fires 16 times across this codebase for the same reason.

The alternative — deriving the dialog's open state from the URL outright and
dropping the local state — is genuinely cleaner, but it means routing every
close path (Escape, cancel, successful save) back through a param removal.
That is a larger change than this bug warrants and is better done on its own.

Unrelated, but worth knowing while looking at CI: `uv run ruff check .` has
been failing on `main` since a251da3, so the API job is red there too. That is
fixed separately in #142.
