### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ whole procedure.
 
 The format is loosely [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## Unreleased
+## [1.0.0] — 2026-08-28
 
 The v1.0.0 hardening pass ([ROADMAP.md](ROADMAP.md) Phase 4). This is where the
 API contract stops moving, so it is deliberately where the breaking changes are
@@ -138,5 +138,6 @@ first** — the encrypted backup in the app covers the ledger, and a
 The first release: the double-entry ledger, envelope budgeting, seven import
 formats, the rules engine, scheduled transactions, and reports.
 
+[1.0.0]: https://github.com/AshishKapoor/fintrack/releases/tag/v1.0.0
 [0.2.0]: https://github.com/AshishKapoor/fintrack/releases/tag/v0.2.0
 [0.1.0]: https://github.com/AshishKapoor/fintrack/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,10 @@ four.
 - Backend changes need tests. `apps/api/pft/tests/` has suites for API smoke,
   the finance domain, ledger invariants, filtering, tenant isolation,
   organizations, the audit log, auth hardening, and account deletion.
+- New list endpoints paginate. `pft/pagination.py`'s `StandardPagination` is
+  applied everywhere, so a list response is always
+  `{count, next, previous, results}`; `tests/test_pagination.py` asserts it for
+  every route, and a viewset that opts out will fail there.
 - **Anything that touches a queryset, serializer or permission must have a
   cross-tenant test** in `apps/api/pft/tests/test_tenant_isolation.py`. This is a
   multi-user finance app; "user B cannot see or change user A's data" is the

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Track income, expenses, budgets, and financial goals on your own server —
 no subscriptions, no third-party services, no vendor lock-in.
 
+[![CI](https://github.com/AshishKapoor/fintrack/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AshishKapoor/fintrack/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/)
@@ -268,6 +269,11 @@ cd apps/web && pnpm run test              # vitest units
 docker compose up -d && cd apps/web && pnpm exec playwright test   # e2e against the real stack
 ```
 
+The end-to-end suite includes `e2e/accessibility.spec.ts`, which runs axe over
+every page and both modal surfaces; it fails the build on a new violation. All of
+the above runs in CI, along with diff gates that fail if the committed schema,
+the web client, or either SDK drifts from the backend.
+
 Missing `.env` files are created automatically (via `./setup.sh configure`)
 before any Docker-based target runs — no separate bootstrap step is needed.
 
@@ -283,6 +289,16 @@ FinTrack is API-first. Interactive documentation is served by the backend at
   - `transactions`, `postings`, `scheduled-transactions`, `rules`
   - `budget-months`, `envelope-assignments`, `reports`
   - `exports`, `imports`, `backups`
+
+Every list endpoint is paginated and returns the envelope
+`{count, next, previous, results}` — never a bare array. Default page size is
+50; `?page_size=` raises it to at most 500, and a client that wants everything
+follows `next` until it is null.
+
+The flat `/api/v1/{transactions,categories,budgets}` endpoints that once sat
+alongside the ledger were retired in v1.0. Migration `0017` carries their rows
+into the ledger, so nothing recorded through them is lost — see
+[CHANGELOG.md](CHANGELOG.md) for the upgrade notes.
 
 ### Official SDKs
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -33,11 +33,15 @@ app/                Django project: settings (base/dev/prod), urls, celery
 pft/                the finance domain
 ├── models.py       User, Organization, BudgetFile, the ledger models
 ├── tenancy.py      budget_file_q() — every queryset is scoped through this
+├── pagination.py   StandardPagination — the one class every list endpoint uses
 ├── finance_views.py / finance_serializers.py / finance_services.py
 ├── org_views.py    workspaces, members, invitations
 ├── audit.py        audit_views.py — manager-only audit log
+├── bank_sync.py    bank_sync_gocardless.py / bank_sync_simplefin.py
+├── fx_rates.py     daily ECB reference rates and conversion
+├── ai_categorization.py, notifications.py, crypto.py, demo_mode.py
 ├── tasks.py        Celery tasks (imports, exports)
-└── tests/          nine suites; tenant isolation is the one that matters most
+└── tests/          one suite per domain; tenant isolation matters most
 ```
 
 ## Development
@@ -52,6 +56,16 @@ uv run manage.py spectacular --file ../web/schema/pft.yaml   # after API changes
 The schema command matters: CI fails if the committed schema, the web client,
 or either SDK drifts from the backend. See "If you change the API" in
 CONTRIBUTING.md.
+
+Two contracts a new endpoint has to honour:
+
+- **Pagination.** Every list endpoint uses `pagination.StandardPagination` and
+  returns `{count, next, previous, results}` — page size 50, `?page_size=`
+  capped at 500. A viewset returning a bare array is a bug; `tests/test_pagination.py`
+  is where it gets caught.
+- **Tenancy.** Every queryset is scoped through `tenancy.budget_file_q()`, and
+  anything touching a queryset, serializer or permission needs a cross-tenant
+  case in `tests/test_tenant_isolation.py`.
 
 Useful management commands:
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fintrack-api"
-version = "0.1.0"
+version = "1.0.0"
 description = "FinTrack API - privacy-first, self-hostable personal finance tracker"
 readme = "README.md"
 license = "MIT"

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "fintrack-api"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "celery", extra = ["redis"] },

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -21,17 +21,24 @@ pnpm's version is pinned by `packageManager`; `corepack enable` once and forget.
 ```
 app/
 ├── pages/                one directory per route
-├── components/           feature components (ui/ = shadcn primitives)
+├── components/           feature components (ui/ = shadcn primitives);
+│                         error-boundary.tsx catches render crashes
 ├── client/
-│   ├── httpPFTClient.ts  axios: auth header, 401 refresh-and-retry, toasts
+│   ├── httpPFTClient.ts  axios: auth header, 401 refresh-and-retry, toasts,
+│   │                     and the offline write queue that replays on reconnect
 │   └── gen/              orval output — tracked in git, never hand-edited
 ├── lib/                  ledger.ts (posting builders, SWR invalidation),
-│                         auth, backup, import/export, dates
+│                         paginated.ts (page envelope helpers), auth, backup,
+│                         import/export, dates
 ├── context/              currency + organization providers
 └── hooks/                Zustand stores
-e2e/                      Playwright suite (runs against the Docker stack)
+e2e/                      Playwright suite (runs against the Docker stack),
+                          including accessibility.spec.ts — axe over every page
 schema/pft.yaml           OpenAPI schema — the contract with the backend
 ```
+
+Every list endpoint returns `{count, next, previous, results}`; read pages
+through `lib/paginated.ts` rather than treating a response as an array.
 
 ## Development
 
@@ -50,5 +57,6 @@ pnpm exec playwright install chromium
 pnpm exec playwright test
 ```
 
-CI runs all of the above, plus a diff gate that fails if `app/client/gen/`
+CI runs all of the above — the Playwright suite included, so a new axe
+violation fails the build — plus a diff gate that fails if `app/client/gen/`
 does not match `schema/pft.yaml`.

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fintrack-sdk"
-version = "0.1.0"
+version = "1.0.0"
 description = "Typed Python client for the FinTrack API, generated from its OpenAPI schema."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fintrack/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Typed TypeScript client for the FinTrack API, generated from its OpenAPI schema.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release prep for **v1.0.0** — the Phase 4 hardening pass that PR #145 merged, plus the README work it left behind.

## What's in here

- **`docs:`** — the READMEs had not followed the API changes. The root README documented the API surface without mentioning the page envelope or the retired flat resources; `apps/api/README.md` claimed nine test suites (there are 27) and predated `pagination.py`, bank sync, FX rates and notifications; `apps/web/README.md` described the client without the offline queue, the error boundary or `lib/paginated.ts`; CONTRIBUTING covered the tenancy contract but not the pagination one. CI badge added too.
- **`chore(release):`** — CHANGELOG's Unreleased section cut as `1.0.0` (2026-08-28), and the three version manifests moved together to `1.0.0`. `apps/api/uv.lock` records the project version, so it is relocked — otherwise `uv sync --frozen` fails in CI.

Major, not minor: Phase 4 changed the HTTP contract (flat resources removed, `V2` suffix dropped, every list endpoint paginated). That is RELEASING.md's rule for a major.

## Checklist state (RELEASING.md)

- [x] 1. `main` green — CI success on `1ba9e3d`
- [x] 2. No generated-artifact drift — CI's schema/orval/SDK gates passed on `1ba9e3d`; this PR touches no schema input
- [x] 3. `make feature-audit` — 0 findings, 0 matrix errors, 0 gate violations; `parity-report.md` regenerated with no diff
- [ ] 4. Upgrade test against the previous release's volume — not run
- [x] 5. Changelog written
- [x] 6. Versions bumped
- [ ] 7. Tag pushed — after this merges
- [ ] 8. Watch the publish workflow
- [ ] 9. Release notes

## Blocker for the tag

`NPM_TOKEN` and `PYPI_API_TOKEN` are not configured on this repository (`gh secret list` is empty). `release.yml` treats a missing token as a hard failure rather than a skip, so tagging today publishes the GHCR images and then fails both SDK jobs. Neither package has ever reached its registry — npm 404s on `@fintrack/sdk` and PyPI has no `fintrack-sdk` releases — so the v0.1.0 and v0.2.0 release runs failed the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wkd2Kj5reBAiWre2nU8SEV