### PR TITLE
fix(landing): deploy only on a project version bump, and document the broken Vercel root

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,9 @@ explained in full below.
   schedule state lives on the same `api_run` volume as the generated
   `SECRET_KEY`, so a restart does not lose track of when a task last fired.
 - `apps/landing/` is a separate Next.js marketing site. It is **not** part of the
-  self-hosted stack and is not referenced by `docker-compose.yml`.
+  self-hosted stack and is not referenced by `docker-compose.yml`. It deploys
+  through Vercel only when the project version is bumped, not on every merge —
+  see `apps/landing/README.md`.
 
 ## The API surface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ first** — the encrypted backup in the app covers the ledger, and a
 - `scripts/feature_audit.py` never scanned `pft/finance_urls.py`, so the three
   AI-categorization endpoints had reported as schema-only since the day they
   shipped.
+- **The landing site had not deployed since 2026-08-13.** Vercel built it on
+  every push of every branch, which first exhausted the free tier's build
+  quota, and the monorepo restructure left the project's Root Directory
+  pointing at the old `landing/` path. Deploys are now gated by an Ignored
+  Build Step (`apps/landing/vercel.json`) that skips every build unless the
+  project version was bumped — so the site redeploys once per release, not
+  per merge. The Root Directory fix is a dashboard setting; it is documented
+  in `apps/landing/README.md`.
 
 ## [0.2.0] — 2026-08-13
 

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,0 +1,36 @@
+# FinTrack landing site
+
+The Next.js marketing site served at <https://fintrack.sannty.in>. It is not
+part of the self-hosted stack — `docker-compose.yml` never references it — so
+nothing here affects an installed FinTrack.
+
+```bash
+pnpm install
+pnpm dev     # http://localhost:3000
+pnpm build   # what CI and Vercel run; lint and type errors fail the build
+```
+
+## Deployment
+
+The site deploys through the Vercel Git integration (project `fintrack`),
+**only when the project version is bumped** — the release-PR merge that moves
+the three version manifests together (RELEASING.md step 6). Every other push
+to `main` is skipped by the Ignored Build Step in [`vercel.json`](vercel.json),
+which runs [`scripts/ignore-build.sh`](scripts/ignore-build.sh): it compares
+`packages/sdk-ts/package.json`'s `version` between the last deployed commit
+and the pushed one, and cancels the build when it has not moved.
+
+Deploying on every push is what broke the site's deploys in the first place:
+this repository is busy enough (Dependabot alone) that the account hit the
+free tier's build rate limit on 2026-08-13, and every deployment since failed.
+
+### One-time Vercel dashboard settings
+
+These cannot be set from the repository; check them if deploys fail:
+
+- **Root Directory** must be `apps/landing`. The 2026-08 monorepo restructure
+  (`d44c13d`) moved the site from `landing/` to `apps/landing/`, and a project
+  still pointing at the old path fails every deployment before the build
+  starts. This also is what makes Vercel read this directory's `vercel.json`.
+- Framework preset: Next.js. No other overrides are needed — install and
+  build come from `package.json` (`packageManager` pins pnpm).

--- a/apps/landing/scripts/ignore-build.sh
+++ b/apps/landing/scripts/ignore-build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Vercel Ignored Build Step for the landing site (wired up in vercel.json).
+#
+# Exit code contract, per https://vercel.com/docs/projects/overview#ignored-build-step:
+#   exit 1 -> proceed with the build
+#   exit 0 -> skip the deployment
+#
+# The site deploys only when the project version moves — the release-PR merge
+# that RELEASING.md step 6 describes — not on every merge to main. Deploying on
+# every push is what exhausted the free tier's build quota (the "Deployment
+# rate limited" failures of 2026-08-13) and it redeploys marketing copy for
+# changes that cannot affect it.
+#
+# The version is read from packages/sdk-ts/package.json. RELEASING.md moves it
+# in lockstep with apps/api/pyproject.toml and packages/sdk-py/pyproject.toml,
+# and it is the one of the three that is JSON, so no TOML parsing here.
+set -u
+
+MANIFEST="packages/sdk-ts/package.json"
+
+# Paths after "<rev>:" are repo-root relative, so this works from apps/landing
+# (Vercel runs the ignore command from the project's Root Directory).
+version_at() {
+  git show "$1:$MANIFEST" 2>/dev/null | node -e '
+    let d = "";
+    process.stdin.on("data", (c) => (d += c));
+    process.stdin.on("end", () => {
+      try {
+        process.stdout.write(JSON.parse(d).version || "");
+      } catch {
+        /* unreadable manifest -> empty, handled below */
+      }
+    });
+  '
+}
+
+# Prefer the last successfully deployed commit (Vercel exposes it to the
+# ignore step); a version bump then deploys even if it landed a few commits
+# before this push. Fall back to the first parent when that commit is not in
+# the shallow clone — for a merge to main, HEAD^ is the previous main, so the
+# whole merged PR is still covered.
+base="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+  base="HEAD^"
+fi
+
+current="$(version_at HEAD)"
+previous="$(version_at "$base")"
+
+if [ -z "$current" ] || [ -z "$previous" ]; then
+  echo "Could not read $MANIFEST at HEAD and $base — building to be safe."
+  exit 1
+fi
+
+if [ "$current" != "$previous" ]; then
+  echo "Project version bumped ($previous -> $current) — deploying."
+  exit 1
+fi
+
+echo "Project version unchanged ($current since $base) — skipping deploy."
+exit 0

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/ignore-build.sh"
+}


### PR DESCRIPTION
## What does this change?

Adds a Vercel Ignored Build Step for the landing site (`apps/landing/vercel.json` + `scripts/ignore-build.sh`) so it deploys **only when the project version is bumped** — the release-PR merge that moves the three version manifests together per RELEASING.md step 6 — instead of on every push of every branch. Also adds `apps/landing/README.md` documenting the deployment model and the one dashboard setting that cannot be fixed from the repo.

## Why?

The landing site at fintrack.sannty.in has not deployed successfully since **2026-08-13**. Two stacked causes:

1. **Vercel built the project on every push of every branch.** With this repo's traffic (Dependabot alone), that exhausted the free tier's build quota — the Vercel status on PR #100 reads *"Deployment rate limited — retry in 24 hours."*
2. **The monorepo restructure (`d44c13d`) moved the site from `landing/` to `apps/landing/` that same day**, and the Vercel project's Root Directory still points at the old path — so every deployment since fails before the build starts, even on pushes that touch nothing under `apps/landing` (the v1.0.0 release PR #173 shows the same failed Vercel status). The site itself builds clean.

The ignore script compares `packages/sdk-ts/package.json`'s `version` (the JSON one of the three lockstep manifests) between the last successfully deployed commit (`VERCEL_GIT_PREVIOUS_SHA`, falling back to `HEAD^` when the shallow clone lacks it) and the pushed commit. Version moved → build; otherwise → skip. Dependabot bumps *inside* `packages/sdk-ts/package.json` don't trigger a deploy, because the `version` field is parsed rather than the file diffed.

**One manual step remains (dashboard-only, documented in the new README):** the Vercel project's **Root Directory must be set to `apps/landing`**. Until then deploys keep failing regardless of repo contents — it is also what makes Vercel read the new `vercel.json`. Once flipped, this PR plus the #173 release merge (0.1.0 → 1.0.0) produces the first successful deploy in two weeks.

## How was it verified?

- [x] `cd apps/landing && pnpm install --frozen-lockfile && pnpm run build` — clean build (rules out the page code as the deploy failure)
- [x] Tried it manually: exercised the ignore script's four paths locally — version unchanged → exit 0 (skip); simulated 0.1.0 → 1.0.0 bump commit → exit 1 (deploy); `VERCEL_GIT_PREVIOUS_SHA` pointing at an older commit → exit 1; bogus `VERCEL_GIT_PREVIOUS_SHA` → falls back to `HEAD^` correctly. `bash -n` passes; `vercel.json` parses; the script is committed with its executable bit.

## Checklist

- [x] No secrets, `.env` files, or generated clients committed
- [x] Docs updated if the setup steps or API surface changed — `apps/landing/README.md` (new), `ARCHITECTURE.md`, `CHANGELOG.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hyDFQhe2u7MwXT2PNqfCP

---
_Generated by [Claude Code](https://claude.ai/code/session_014hyDFQhe2u7MwXT2PNqfCP)_