### PR TITLE
fix: make Docker stack work on any host or IP out of the box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,17 @@ SECRET_KEY=
 DEBUG=False
 DJANGO_ENV=production
 
-# Space- or comma-separated. Add your own hostname before going public.
-DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+# Space- or comma-separated. "*" accepts any host, so the stack works whether
+# you browse it via localhost, a LAN IP, or a hostname - safe with the shipped
+# same-origin nginx proxy (the browser never talks to Django cross-origin).
+# Pin it to your real hostname for an internet-facing instance:
+#   DJANGO_ALLOWED_HOSTS=fintrack.example.com
+DJANGO_ALLOWED_HOSTS=*
 
-# Where the web UI is served from, so the API accepts its requests.
+# Only consulted for cross-origin setups (serving the web UI and API from
+# different origins). The default Docker stack proxies /api/ same-origin, so
+# these never come into play there - but set them to your real origin if you
+# split the two apart.
 CORS_ALLOWED_ORIGINS=http://localhost:5173
 CSRF_TRUSTED_ORIGINS=http://localhost:5173
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,19 @@ x-django-env: &django-env
   DEBUG: ${DEBUG:-False}
   SECRET_KEY: ${SECRET_KEY:-}
   SECRET_KEY_FILE: /app/run/.secret_key
-  DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost 127.0.0.1 [::1]}
+  # "*" so the stack works unmodified whether you browse it via localhost, a
+  # LAN IP, or a hostname - the previous localhost-only default made Django
+  # reject every proxied API call with a 400 DisallowedHost on any other host,
+  # which surfaced in the UI as signup/login failing (and read like a CORS
+  # error, though no cross-origin request is ever involved: the browser talks
+  # only to the web container, whose nginx proxies /api/ same-origin). "*" is
+  # safe in this topology - auth is JWT, and nothing derives links or redirects
+  # from the Host header - but pin it to your real hostname for an
+  # internet-facing instance (docs/self-hosting.md) for defense in depth.
+  DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
+  # Only consulted for cross-origin setups (e.g. `pnpm dev` against this API,
+  # or serving web and api from different domains). The shipped same-origin
+  # nginx proxy never triggers CORS, whatever host or IP you browse from.
   CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173}
   CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:5173}
   SECURE_SSL: ${SECURE_SSL:-False}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -19,7 +19,11 @@ SECRET_KEY=$(openssl rand -base64 48)
 # 2. A real database password.
 POSTGRES_PASSWORD=<something long>
 
-# 3. Your own hostname.
+# 3. Your own hostname. Out of the box DJANGO_ALLOWED_HOSTS is "*" so the
+#    stack works on localhost, a LAN IP, or any hostname without edits - the
+#    browser only ever talks to the web container, which proxies /api/
+#    same-origin, so nothing here is reachable cross-origin anyway. Pin it
+#    once you have a real domain, as defense in depth.
 DJANGO_ALLOWED_HOSTS=fintrack.example.com
 CORS_ALLOWED_ORIGINS=https://fintrack.example.com
 CSRF_TRUSTED_ORIGINS=https://fintrack.example.com
@@ -386,16 +390,27 @@ status rather than just "running".
 
 ## Troubleshooting
 
-**The stack starts but the web app cannot reach the API.** Check
-`CORS_ALLOWED_ORIGINS` matches the scheme and host you are actually browsing
-from, including the port if it is non-standard.
+**The stack starts but the web app cannot reach the API — signup or login
+fails on the first request.** In the shipped Docker stack this is almost never
+CORS: the browser talks only to the `web` container, whose nginx proxies
+`/api/` to the backend on the same origin, so no cross-origin request exists
+to be blocked. The usual cause is an `.env` created from an older
+`.env.example` that pins `DJANGO_ALLOWED_HOSTS` to localhost — Django then
+answers every API call with `400 DisallowedHost` when you browse via an IP or
+hostname, which the UI reports as a failed signup. Set
+`DJANGO_ALLOWED_HOSTS=*` (the current default) or add your host to it, then
+`docker compose up -d` again. `CORS_ALLOWED_ORIGINS` only matters if you
+serve the web app and API from *different* origins — then it must match the
+scheme, host, and port you are browsing from.
 
 **Redirect loop after enabling TLS.** Your proxy is not sending
 `X-Forwarded-Proto: https`, so Django thinks the request is plain HTTP and
 redirects again.
 
-**`DisallowedHost` errors.** Add your hostname to `DJANGO_ALLOWED_HOSTS`. It
-accepts spaces or commas as separators.
+**`DisallowedHost` errors.** Your `.env` overrides the default
+`DJANGO_ALLOWED_HOSTS=*` with a list that does not include the hostname you
+are browsing from. Add it (spaces or commas as separators), or set the value
+back to `*`.
 
 **Everyone was signed out after a restart.** `SECRET_KEY` was not set, so a new
 one was generated. Set it explicitly in `.env`.


### PR DESCRIPTION
Signing up on a fresh Docker deployment failed unless the site was browsed
via localhost: DJANGO_ALLOWED_HOSTS defaulted to 'localhost 127.0.0.1 [::1]',
so Django answered the very first proxied API call (registration) with
400 DisallowedHost when accessed via a server IP or hostname. The UI
surfaced this as a failed signup that looked like a CORS error - though no
cross-origin request is ever involved, since the web container's nginx
proxies /api/ to the backend on the same origin.

Default DJANGO_ALLOWED_HOSTS to '*' in docker-compose.yml and .env.example.
This is safe in the shipped topology (JWT auth, no Host-derived links or
redirects), and the docs now recommend pinning it to a real hostname as
defense in depth for internet-facing instances. Also clarify in
docs/self-hosting.md and .env.example that CORS_ALLOWED_ORIGINS only
matters when the web app and API are served from different origins, and
update the troubleshooting entries accordingly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ky4oHGefpNsfeVaYTotCLj