### PR TITLE
feat: load theme fonts from Google Fonts on demand

### DIFF
--- a/apps/web/app/components/theme-provider.tsx
+++ b/apps/web/app/components/theme-provider.tsx
@@ -1,4 +1,5 @@
-import { applyThemePreset, clearThemePreset } from '@/lib/apply-theme'
+import { applyThemePreset, clearThemePreset, resolvePresetStyles } from '@/lib/apply-theme'
+import { loadThemeFonts } from '@/lib/theme-fonts'
 import { DEFAULT_THEME_KEY, themePresets } from '@/lib/theme-presets'
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 
@@ -77,6 +78,7 @@ export function ThemeProvider({
       const preset = themePresets.find((p) => p.key === colorTheme)
       if (preset) {
         applyThemePreset(root, preset, mode)
+        loadThemeFonts(resolvePresetStyles(preset, mode))
       } else {
         clearThemePreset(root)
       }

--- a/apps/web/app/lib/theme-fonts.test.ts
+++ b/apps/web/app/lib/theme-fonts.test.ts
@@ -1,0 +1,56 @@
+import { extractGoogleFontFamilies, fontCssUrl, loadThemeFonts } from '@/lib/theme-fonts'
+import { themePresets } from '@/lib/theme-presets'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const doom64 = themePresets.find((p) => p.key === 'doom-64')!
+
+describe('extractGoogleFontFamilies', () => {
+  it('returns the first family of each font stack', () => {
+    const families = extractGoogleFontFamilies({
+      'font-sans': 'Oxanium, monospace',
+      'font-mono': 'Source Code Pro, monospace',
+    })
+    expect(families).toEqual(['Oxanium', 'Source Code Pro'])
+  })
+
+  it('skips system and non-Google fonts', () => {
+    const families = extractGoogleFontFamilies({
+      'font-sans': 'Signifier, serif',
+      'font-serif': 'Georgia, serif',
+      'font-mono': 'Menlo, monospace',
+    })
+    expect(families).toEqual([])
+  })
+
+  it('dedupes and strips quotes', () => {
+    const families = extractGoogleFontFamilies({
+      'font-sans': "'Space Mono', monospace",
+      'font-mono': 'Space Mono, monospace',
+    })
+    expect(families).toEqual(['Space Mono'])
+  })
+})
+
+describe('loadThemeFonts', () => {
+  afterEach(() => {
+    document.head
+      .querySelectorAll("link[rel='stylesheet'], link[rel='preconnect']")
+      .forEach((link) => link.remove())
+  })
+
+  it('injects one stylesheet link per family plus preconnects, without duplicates', () => {
+    loadThemeFonts(doom64.styles.light)
+    loadThemeFonts(doom64.styles.light)
+
+    const hrefs = [...document.head.querySelectorAll("link[rel='stylesheet']")].map(
+      (link) => (link as HTMLLinkElement).href,
+    )
+    expect(hrefs).toEqual([fontCssUrl('Oxanium'), fontCssUrl('Source Code Pro')])
+    expect(document.head.querySelectorAll("link[rel='preconnect']")).toHaveLength(2)
+  })
+
+  it('does nothing for styles without loadable fonts', () => {
+    loadThemeFonts({ 'font-sans': 'Georgia, serif' })
+    expect(document.head.querySelector("link[rel='stylesheet']")).toBeNull()
+  })
+})

--- a/apps/web/app/lib/theme-fonts.ts
+++ b/apps/web/app/lib/theme-fonts.ts
@@ -1,0 +1,87 @@
+import type { ThemeStyleProps } from '@/lib/theme-presets'
+
+// Font families referenced by the tweakcn presets that are served by Google
+// Fonts (each verified against the css2 API). System and commercial fonts
+// (Georgia, Menlo, Signifier, …) are excluded — they either need no loading
+// or cannot be loaded from Google Fonts.
+const GOOGLE_FONT_FAMILIES = new Set([
+  'Antic',
+  'Architects Daughter',
+  'DM Sans',
+  'Fira Code',
+  'Geist',
+  'Geist Mono',
+  'IBM Plex Mono',
+  'Inter',
+  'JetBrains Mono',
+  'Libre Baskerville',
+  'Lora',
+  'Merriweather',
+  'Montserrat',
+  'Open Sans',
+  'Outfit',
+  'Oxanium',
+  'Playfair Display',
+  'Plus Jakarta Sans',
+  'Poppins',
+  'Quicksand',
+  'Roboto',
+  'Roboto Mono',
+  'Source Code Pro',
+  'Source Serif 4',
+  'Space Mono',
+  'Ubuntu Mono',
+])
+
+// The css2 API serves the nearest available weight, so one weight set works
+// for every family above (verified: all return 200).
+const FONT_WEIGHTS = '400;500;600;700'
+
+const FONT_KEYS = ['font-sans', 'font-serif', 'font-mono'] as const
+
+/** First family of each font stack in the styles, deduped, loadable ones only. */
+export function extractGoogleFontFamilies(styles: ThemeStyleProps): string[] {
+  const families = new Set<string>()
+  for (const key of FONT_KEYS) {
+    const stack = styles[key]
+    if (!stack) continue
+    const first = stack.split(',')[0].trim().replace(/^["']|["']$/g, '')
+    if (GOOGLE_FONT_FAMILIES.has(first)) families.add(first)
+  }
+  return [...families]
+}
+
+export function fontCssUrl(family: string): string {
+  return `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${FONT_WEIGHTS}&display=swap`
+}
+
+function ensurePreconnect(href: string, crossOrigin: boolean) {
+  if (document.head.querySelector(`link[rel='preconnect'][href='${href}']`)) return
+  const link = document.createElement('link')
+  link.rel = 'preconnect'
+  link.href = href
+  if (crossOrigin) link.crossOrigin = 'anonymous'
+  document.head.appendChild(link)
+}
+
+/**
+ * Inject stylesheet links for the theme's fonts. Each family is added once
+ * per page load and stays cached by the browser after that; families already
+ * present are skipped, so calling this on every theme change is cheap.
+ */
+export function loadThemeFonts(styles: ThemeStyleProps) {
+  const families = extractGoogleFontFamilies(styles)
+  if (families.length === 0) return
+
+  ensurePreconnect('https://fonts.googleapis.com', false)
+  ensurePreconnect('https://fonts.gstatic.com', true)
+
+  for (const family of families) {
+    const href = fontCssUrl(family)
+    if (document.head.querySelector(`link[rel='stylesheet'][href='${href}']`)) continue
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = href
+    document.head.appendChild(link)
+  }
+}

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -11,7 +11,7 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     # No external hosts are needed: fonts are self-hosted and analytics is
     # opt-in. connect-src stays 'self' because the API is proxied under /api/.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
## What does this change?

Follow-up to #182: when a tweakcn color theme is applied, its Google-hosted font families are now loaded on demand via injected stylesheet links, so themes render with their intended typography (e.g. Doom 64 in Oxanium, Notebook in Architects Daughter) instead of falling back to generic families.

## Why?

The theme presets carry full font stacks, but the app only bundles Inter — every themed font silently fell back, losing a big part of each theme's character. This loads exactly the fonts the active theme needs (26 Google Fonts families across all presets, each verified against the css2 API; system and commercial fonts are skipped), once per page load, with `display=swap` so text never blocks on the download. The nginx CSP is extended to allow `fonts.googleapis.com` stylesheets and `fonts.gstatic.com` font files, which it otherwise blocks in production.

## How was it verified?

- [x] `cd apps/web && pnpm run lint && pnpm run build`
- [x] Tried it manually (drove the app in a browser via Playwright: applied Notebook and Doom 64, confirmed the `<link>` injection, `document.fonts` face statuses, and that Architects Daughter / Oxanium actually render — plus 5 new unit tests in `theme-fonts.test.ts`, 97 passing total)

## Checklist

- [x] No secrets, `.env` files, or generated clients committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X6z1zg4AyZrRT5m85sZ3A

---
_Generated by [Claude Code](https://claude.ai/code/session_015X6z1zg4AyZrRT5m85sZ3A)_