### PR TITLE
feat(compose)!: move Postgres from 16 to 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,8 +114,8 @@ updates:
     schedule:
       interval: weekly
 
-  # postgres:16-alpine and redis:7-alpine live in the compose files at the
-  # repo root, outside every directory above, so nothing was tracking them.
+  # The postgres and redis images live in the compose files at the repo root,
+  # outside every directory above, so nothing was tracking them.
   - package-ecosystem: docker-compose
     directory: /
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ whole procedure.
 
 The format is loosely [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Upgrading
+
+- **Postgres moves from 16 to 18, and existing installs need a dump and
+  restore.** Postgres never reads a data directory written by a different
+  major version, and 18+ also changes where the images keep the cluster: the
+  compose volume is now mounted at `/var/lib/postgresql` rather than
+  `/var/lib/postgresql/data`, with `PGDATA` left at the image default of
+  `/var/lib/postgresql/18/docker`. Upgrading without migrating starts the
+  stack against a freshly initialised, empty cluster — the 16 data is still in
+  the volume and recoverable, but FinTrack comes up looking empty. The
+  procedure is in [docs/self-hosting.md](docs/self-hosting.md), "Upgrading
+  across a Postgres major version". Managed-Postgres deployments
+  (`render.yaml`) are unaffected.
+
+### Changed
+
+- Redis moves from 7 to 8 in the compose stack. No action needed: Redis only
+  carries queued jobs in flight here.
+
 ## [1.0.0] — 2026-08-28
 
 The v1.0.0 hardening pass ([ROADMAP.md](ROADMAP.md) Phase 4). This is where the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,13 +207,23 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-fintrack}
       POSTGRES_USER: ${POSTGRES_USER:-fintrack}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-fintrack_local_dev}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # Mounted at /var/lib/postgresql, not at .../data. From 18 on, these
+      # images keep the cluster in a major-version-specific subdirectory
+      # (PGDATA defaults to /var/lib/postgresql/18/docker) so that both
+      # clusters sit under one mount and `pg_upgrade --link` does not have to
+      # cross a mount boundary. Mounting .../data instead makes 18+ refuse to
+      # start. PGDATA is deliberately left at the image default so it tracks
+      # the image tag rather than drifting out of sync with it.
+      #
+      # Moving an existing 16 volume onto 18 is NOT automatic - see
+      # docs/self-hosting.md, "Upgrading across a Postgres major version".
+      - postgres_data:/var/lib/postgresql
     networks:
       - fintrack_network
     # Not published to the host by default. Uncomment only if you need to connect

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -389,10 +389,12 @@ docker run --rm \
 
 ```bash
 # 4. Take the new compose file, then start from an empty volume so 18
-#    initialises its own cluster.
+#    initialises its own cluster. --wait blocks on the healthcheck, which
+#    matters here: initdb on a fresh volume takes a few seconds, and without
+#    it the restore below races the database and fails to connect.
 git pull
 docker volume rm fintrack_postgres_data
-docker compose up -d db
+docker compose up -d --wait db
 ```
 
 ```bash

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -344,6 +344,75 @@ Watch it come up:
 docker compose logs -f migrate api
 ```
 
+### Upgrading across a Postgres major version
+
+FinTrack now runs `postgres:18-alpine`. Postgres never reads a data directory
+written by a different major version, so moving from a 16 volume is a dump and
+restore — there is no in-place `docker compose up -d` for it.
+
+Two things changed at once, and the second is the one that surprises people:
+
+- The image is `18-alpine` rather than `16-alpine`.
+- The volume is mounted at `/var/lib/postgresql` rather than
+  `/var/lib/postgresql/data`, because 18+ keeps the cluster in a
+  major-version-specific subdirectory underneath that mount.
+
+**If you upgrade without doing the steps below, the stack still starts — with
+an empty database.** Postgres finds nothing at the new location and initialises
+a fresh cluster there, so FinTrack comes up with no accounts and no
+transactions. Your 16 data is still sitting in the same volume, untouched, so
+this is recoverable; it just does not look that way from the UI. Do the dump
+first and you never see it.
+
+Run every step from your install directory, on the **old** stack, before
+pulling the new compose file:
+
+```bash
+cd /srv/fintrack
+
+# 1. Dump, while 16 is still the running image.
+docker compose exec -T db pg_dump -U fintrack fintrack \
+  | gzip > fintrack-pre-pg18-$(date +%F).sql.gz
+
+# 2. Stop everything.
+docker compose down
+```
+
+```bash
+# 3. Keep the old volume as a tarball, so 16 is recoverable if the restore
+#    goes wrong. The volume is prefixed with the compose project name, which
+#    defaults to the directory name - check `docker volume ls` if you renamed it.
+docker run --rm \
+  -v fintrack_postgres_data:/from -v "$PWD":/to alpine \
+  tar czf /to/postgres_data-pg16-$(date +%F).tar.gz -C /from .
+```
+
+```bash
+# 4. Take the new compose file, then start from an empty volume so 18
+#    initialises its own cluster.
+git pull
+docker volume rm fintrack_postgres_data
+docker compose up -d db
+```
+
+```bash
+# 5. Restore into it, then bring the rest of the stack up.
+gunzip -c fintrack-pre-pg18-*.sql.gz \
+  | docker compose exec -T db psql -U fintrack -d fintrack
+docker compose up -d
+```
+
+Check it before deleting the tarball:
+
+```bash
+docker compose exec -T db psql -U fintrack -d fintrack \
+  -c 'select count(*) from pft_ledgertransaction;'
+```
+
+`SECRET_KEY` and `FINTRACK_SYNC_ENCRYPTION_KEY` live in `.env`, not in the
+database, so a dump and restore does not disturb bank sync credentials or
+stored LLM keys. Keep `.env` as it is.
+
 ## Housekeeping
 
 Import and export jobs retain their payloads in the database, and those


### PR DESCRIPTION
## What does this change?

Takes the `postgres:16-alpine` → `18-alpine` bump from #158 and adds the
compose and documentation changes it actually needs. Supersedes #158.

Closes #158

> [!WARNING]
> Breaking for existing self-hosted installs. They need a dump and restore
> before upgrading — see the CHANGELOG entry and
> `docs/self-hosting.md` → "Upgrading across a Postgres major version".

## Why?

#158 on its own fails the `Docker stack smoke test` and `End-to-end
(Playwright)` jobs, and not because of anything to do with old data — it
breaks a **fresh** install. From 18 on, these images keep the cluster in a
major-version-specific subdirectory and expect a single mount at
`/var/lib/postgresql`, so `pg_upgrade --link` can see both clusters without
crossing a mount boundary. We mount at `/var/lib/postgresql/data`, and 18
refuses to start on it:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

So the mount moves up one level. `PGDATA` is deliberately left at the image
default (`/var/lib/postgresql/18/docker`): pinning it here would encode the
major version in two places and let them drift apart on the next bump, whereas
the default always tracks the tag.

### The part worth reviewing carefully

Existing installs cannot be upgraded in place — Postgres never reads a data
directory written by a different major version. The awkward part is that the
failure is **quiet**: 18 finds nothing at the new location, initialises an
empty cluster, and the app comes up looking wiped. The 16 files are still in
the volume and fully recoverable, but nothing in the UI says so.

I could not make that failure loud from compose alone; the image's own guard
only fires for data sitting at `/var/lib/postgresql/data`, which is not where
it lands once the mount moves. What this PR does instead is put the procedure
in front of people in both places they would look — `docs/self-hosting.md` and
the CHANGELOG's `Upgrading` heading — with a sequence that dumps first, keeps
the old volume as a tarball, and only then removes it. If you would rather have
a hard stop than a documented one, say so and I will add an init check.

Managed Postgres deployments (`render.yaml`) are unaffected.

## How was it verified?

- [x] `docker compose -f docker-compose.yml config` and `-f docker-compose.yml
      -f docker-compose.dev.yml config` both resolve, with the db service
      showing `postgres:18-alpine`
- [x] Every compose and workflow YAML file parses
- [x] Confirmed no `postgres:16` or `/var/lib/postgresql/data` reference is
      left outside the CHANGELOG and the upgrade doc, where they are
      deliberate
- [x] Checked the verification query in the new doc against the schema — the
      table is `pft_ledgertransaction` (app label `pft`, no `db_table`
      overrides)
- [ ] **Not run locally**: `docker compose build && docker compose up -d`.
      This session's egress policy blocks Docker Hub's blob CDN
      (`production.cloudfront.docker.com`, 403), so no image could be pulled.
      The `Docker stack smoke test` and `End-to-end (Playwright)` jobs are the
      real gate here — both are exactly the jobs that failed on #158, and both
      run against this `docker-compose.yml`.

## Follow-up this PR could not include

`.github/workflows/ci.yml` still pins `postgres:16-alpine` for the `api` job's
service container. Pushing it was rejected — the token here has no `workflows`
permission:

```diff
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:18-alpine
```

Worth applying so the unit tests run against the version the stack ships, but
not a coverage gap for this change: the smoke test and E2E jobs both bring up
the real compose stack, so 18 is exercised either way.

## Checklist

- [x] Backend changes to a queryset, serializer or permission come with a
      cross-tenant test in `apps/api/pft/tests/test_tenant_isolation.py` —
      n/a, no backend changes
- [x] No secrets, `.env` files, or generated clients committed
- [x] Docs updated if the setup steps or API surface changed — new upgrade
      section in `docs/self-hosting.md` plus a CHANGELOG `Upgrading` entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wav5cCXw2XdyNBoJ1c4eHX)_