### PR TITLE
chore(deps): bump react-hook-form from 7.85.0 to 7.86.0 in /apps/web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -82,7 +82,7 @@
     "react": "^19.2.8",
     "react-day-picker": "10.0.1",
     "react-dom": "^19.2.8",
-    "react-hook-form": "^7.85.0",
+    "react-hook-form": "^7.86.0",
     "react-i18next": "^16.4.0",
     "react-resizable-panels": "^4.12.3",
     "react-router-dom": "^7.18.2",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: ^5.9.1
-        version: 5.9.1(@standard-schema/spec@1.1.0)(ajv-errors@3.0.0(ajv@8.20.0))(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)
+        version: 5.9.1(@standard-schema/spec@1.1.0)(ajv-errors@3.0.0(ajv@8.20.0))(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.86.0(react@19.2.8))(zod@4.4.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.20
         version: 1.2.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -159,8 +159,8 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
       react-hook-form:
-        specifier: ^7.85.0
-        version: 7.85.0(react@19.2.8)
+        specifier: ^7.86.0
+        version: 7.86.0(react@19.2.8)
       react-i18next:
         specifier: ^16.4.0
         version: 16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
@@ -4019,8 +4019,8 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
-  react-hook-form@7.85.0:
-    resolution: {integrity: sha512-U2MTriFXnclmV4rOE20p2DcRFv5WEg3FIcBFOKcOLFHDVvGIMPvLTkTWefUsonmlaVy23khVDxDWym6uJVGOzw==}
+  react-hook-form@7.86.0:
+    resolution: {integrity: sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -5192,10 +5192,10 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(ajv-errors@3.0.0(ajv@8.20.0))(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)':
+  '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(ajv-errors@3.0.0(ajv@8.20.0))(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.86.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.85.0(react@19.2.8)
+      react-hook-form: 7.86.0(react@19.2.8)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
       ajv: 8.20.0
@@ -8628,7 +8628,7 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
-  react-hook-form@7.85.0(react@19.2.8):
+  react-hook-form@7.86.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## What does this change?

The same bump as #170, reapplied on top of current `main`. Supersedes #170,
which cannot be brought forward.

Closes #170

## Why?

#170's `apps/web/pnpm-lock.yaml` conflicts with the bumps that have landed in
the same importers block since it was opened — `@hookform/resolvers` 5.9.1
(#132), `react-resizable-panels` 4.12.3 (#171) and
`@testing-library/user-event` 14.6.6 (#134). Dependabot's own rebase of it
failed with "Dependabot tried to update this pull request, but something went
wrong", and resolving it in place is not possible from here: merging `main`
into that branch also pulls in #168's GitHub Actions bumps, and pushing a
change to `.github/workflows/*` needs a `workflows` permission this token does
not have.

Cutting a fresh branch from `main` avoids all of that — the diff is two files
and touches no workflow.

The lockfile is regenerated by pnpm from the updated manifest, not resolved by
hand.

## How was it verified?

- [x] `cd apps/web && pnpm install --frozen-lockfile` — clean, resolves
      `react-hook-form 7.86.0`
- [x] `pnpm run test` — 11 files, 92 tests passing
- [x] `pnpm run lint` — 0 errors (17 pre-existing warnings, unchanged)
- [x] `pnpm run build` — typecheck and build pass
- [x] Confirmed the diff touches no `.github/workflows/` file

## Checklist

- [x] Backend changes to a queryset, serializer or permission come with a
      cross-tenant test in `apps/api/pft/tests/test_tenant_isolation.py` —
      n/a, no backend changes
- [x] No secrets, `.env` files, or generated clients committed
- [x] Docs updated if the setup steps or API surface changed — neither changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wav5cCXw2XdyNBoJ1c4eHX)_