### PR TITLE
fix(auth): show why a signup was rejected instead of "Registration failed"

### DIFF
--- a/apps/api/locale/en/LC_MESSAGES/django.po
+++ b/apps/api/locale/en/LC_MESSAGES/django.po
@@ -71,7 +71,7 @@ msgstr ""
 msgid "Enter a valid email address."
 msgstr ""
 
-msgid "Something went wrong. Please contact support or try again."
+msgid "An account with this email already exists. Try logging in instead."
 msgstr ""
 
 msgid "Your password is required to delete your account."

--- a/apps/api/locale/es/LC_MESSAGES/django.po
+++ b/apps/api/locale/es/LC_MESSAGES/django.po
@@ -68,8 +68,8 @@ msgstr "Sesión cerrada."
 msgid "Enter a valid email address."
 msgstr "Introduce una dirección de correo electrónico válida."
 
-msgid "Something went wrong. Please contact support or try again."
-msgstr "Algo salió mal. Contacta con soporte o inténtalo de nuevo."
+msgid "An account with this email already exists. Try logging in instead."
+msgstr "Ya existe una cuenta con este correo electrónico. Inicia sesión en su lugar."
 
 msgid "Your password is required to delete your account."
 msgstr "Se requiere tu contraseña para eliminar tu cuenta."

--- a/apps/api/pft/tests/test_api_smoke.py
+++ b/apps/api/pft/tests/test_api_smoke.py
@@ -67,6 +67,36 @@ class AuthSmokeTests(APITestCase):
             DEFAULT_EXPENSE_CATEGORIES,
         )
 
+    def test_registering_a_taken_email_says_the_account_exists(self):
+        """The 400 has to name the conflict, not send the user to support.
+
+        The web signup form renders whatever this endpoint puts in the body, so
+        a vague message here is what a self-hoster sees when they retry a signup
+        that already went through (or bootstrapped an admin with
+        FINTRACK_ADMIN_EMAIL): a dead end pointing at the wrong remedy.
+        """
+        User.objects.create_user(
+            email="taken@example.com",
+            username="taken@example.com",
+            password="StrongPass123!",
+        )
+
+        response = self.client.post(
+            "/api/v1/register/",
+            {
+                "email": "taken@example.com",
+                "password": "StrongPass123!",
+                "confirm_password": "StrongPass123!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        message = response.data["email"][0]
+        self.assertIn("already exists", message)
+        self.assertNotIn("contact support", message)
+        self.assertEqual(User.objects.filter(email="taken@example.com").count(), 1)
+
     def test_token_obtain_and_refresh(self):
         User.objects.create_user(
             email="auth-user@example.com",

--- a/apps/api/pft/views.py
+++ b/apps/api/pft/views.py
@@ -199,12 +199,23 @@ class RegisterUserAPIView(generics.CreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Check if email already exists
+        # Check if email already exists.
+        #
+        # This says plainly that the address is taken. It does not leak anything
+        # the endpoint was hiding: a caller already tells a taken address from a
+        # free one by the status alone (400 vs 201), so the previous "Something
+        # went wrong. Please contact support or try again." bought no privacy -
+        # it just sent people who already have an account to support instead of
+        # to the login page. Registration stays rate limited (THROTTLE_REGISTER)
+        # so the status code cannot be swept over an address list cheaply.
         if get_user_model().objects.filter(email=email).exists():
             return Response(
                 {
                     "email": [
-                        _("Something went wrong. Please contact support or try again.")
+                        _(
+                            "An account with this email already exists. "
+                            "Try logging in instead."
+                        )
                     ]
                 },
                 status=status.HTTP_400_BAD_REQUEST,

--- a/apps/web/app/components/user-auth-form.tsx
+++ b/apps/web/app/components/user-auth-form.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useToast } from '@/hooks/use-toast'
-import { register } from '@/lib/auth'
+import { RegisterError, register } from '@/lib/auth'
 import { cn } from '@/lib/utils'
 import { Loader } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -33,9 +33,21 @@ export function UserAuthForm({ className, ...props }: React.HTMLAttributes<HTMLD
       setTimeout(() => {
         window.location.href = '/login'
       }, 1000)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      setError(err.message || t('auth.register.genericError'))
+    } catch (err) {
+      // A rejection carries the server's own reason - "An account with this
+      // email already exists", "Password must be at least 8 characters long" -
+      // already translated by Django. Showing it is the whole point: this form
+      // used to render a bare "Registration failed" for every one of them.
+      if (err instanceof RegisterError && err.kind === 'rejected') {
+        setError(err.message)
+      } else if (err instanceof RegisterError && err.kind === 'network') {
+        setError(t('auth.register.errorNetwork'))
+      } else if (err instanceof RegisterError) {
+        setError(`${t('auth.register.errorServer')} (${err.status})`)
+      } else {
+        setError(t('auth.register.genericError'))
+      }
+      console.error(err)
     } finally {
       setIsLoading(false)
     }

--- a/apps/web/app/lib/auth.test.ts
+++ b/apps/web/app/lib/auth.test.ts
@@ -245,3 +245,106 @@ describe('logout', () => {
     expect(auth.isLoggedIn()).toBe(false)
   })
 })
+
+describe('register', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('surfaces the reason DRF puts in a field key', async () => {
+    // The signup form renders this message verbatim. Reading only `detail` -
+    // which DRF does not send for a validation error - is what turned "this
+    // email is taken" into an unactionable "Registration failed" on screen.
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse(
+        { email: ['An account with this email already exists. Try logging in instead.'] },
+        { status: 400 },
+      ),
+    )
+
+    await expect(auth.register('taken@example.com', 'StrongPass123!')).rejects.toThrow(
+      'An account with this email already exists. Try logging in instead.',
+    )
+  })
+
+  it('surfaces a password rule the same way', async () => {
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ password: ['Password must be at least 8 characters long.'] }, { status: 400 }),
+    )
+
+    await expect(auth.register('new@example.com', 'short')).rejects.toThrow(
+      'Password must be at least 8 characters long.',
+    )
+  })
+
+  it('still prefers `detail` when the server sends one', async () => {
+    // Throttling (THROTTLE_REGISTER) is the case that does use this shape.
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ detail: 'Request was throttled. Expected available in 3546 seconds.' }, { status: 429 }),
+    )
+
+    await expect(auth.register('new@example.com', 'StrongPass123!')).rejects.toThrow(
+      'Request was throttled. Expected available in 3546 seconds.',
+    )
+  })
+
+  it('marks a quotable reason as `rejected` so the form shows it verbatim', async () => {
+    // Django already localized this text; the form must not replace it with a
+    // generic translated string.
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ email: ['Ya existe una cuenta con este correo electrónico.'] }, { status: 400 }),
+    )
+
+    await expect(auth.register('taken@example.com', 'StrongPass123!')).rejects.toMatchObject({
+      kind: 'rejected',
+      status: 400,
+      message: 'Ya existe una cuenta con este correo electrónico.',
+    })
+  })
+
+  it('carries the status when the body is not DRF JSON', async () => {
+    // An nginx 502, or Django's own 400 DisallowedHost page: nothing to quote,
+    // so the status code is the only lead the self-hoster gets.
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('<html>502 Bad Gateway</html>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    )
+
+    await expect(auth.register('new@example.com', 'StrongPass123!')).rejects.toMatchObject({
+      kind: 'server',
+      status: 502,
+    })
+  })
+
+  it('distinguishes an unreachable API from a rejected signup', async () => {
+    const auth = await importAuth()
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await expect(auth.register('new@example.com', 'StrongPass123!')).rejects.toMatchObject({
+      kind: 'network',
+    })
+  })
+
+  it('returns the created user on success', async () => {
+    const auth = await importAuth()
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ email: 'new@example.com', username: 'new@example.com' }, { status: 201 }),
+    )
+
+    await expect(auth.register('new@example.com', 'StrongPass123!')).resolves.toEqual({
+      email: 'new@example.com',
+      username: 'new@example.com',
+    })
+  })
+})

--- a/apps/web/app/lib/auth.ts
+++ b/apps/web/app/lib/auth.ts
@@ -244,15 +244,75 @@ export async function getUserId() {
   return null
 }
 
+/**
+ * Pull the human-readable reason out of a DRF error body.
+ *
+ * DRF reports failed validation as `{field: ["reason", ...]}`; only throttling
+ * and plain action errors use `{detail: "reason"}`. Reading `detail` alone -
+ * which register() used to do - collapsed every actionable reason ("An account
+ * with this email already exists", "Password must be at least 8 characters
+ * long") into an opaque "Registration failed" with nothing to act on. The
+ * axios client's 400 handler (httpPFTClient.ts) already reads both shapes;
+ * the raw fetch() callers in this module need their own copy.
+ */
+function firstErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined
+  const data = body as Record<string, unknown>
+  if (typeof data.detail === 'string') return data.detail
+  for (const value of Object.values(data)) {
+    if (typeof value === 'string') return value
+    if (Array.isArray(value) && typeof value[0] === 'string') return value[0]
+  }
+  return undefined
+}
+
+export type RegisterErrorKind = 'rejected' | 'server' | 'network'
+
+/**
+ * Why a signup failed, in the shape the form can localize.
+ *
+ * Mirrors LoginError above: `kind` picks the translated string, so nothing
+ * here leaks untranslated English onto the page. The exception is `rejected`,
+ * whose `message` is the server's own reason - Django runs it through gettext
+ * (LocaleMiddleware honours Accept-Language), so it arrives already in the
+ * user's language and is far more specific than anything the client knows.
+ */
+export class RegisterError extends Error {
+  kind: RegisterErrorKind
+  status?: number
+
+  constructor(kind: RegisterErrorKind, message: string, status?: number) {
+    super(message)
+    this.name = 'RegisterError'
+    this.kind = kind
+    this.status = status
+  }
+}
+
 export async function register(email: string, password: string) {
-  const response = await fetch(`${PFT_BASE_URL}/api/v1/register/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username: email, email, password, confirm_password: password }),
-  })
+  let response: Response
+  try {
+    response = await fetch(`${PFT_BASE_URL}/api/v1/register/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: email, email, password, confirm_password: password }),
+    })
+  } catch {
+    // fetch only throws on network-level failures - an API that never came up,
+    // or a build carrying a VITE_BASE_DOMAIN that does not resolve from the
+    // browser - never on an HTTP error status.
+    throw new RegisterError('network', 'Could not reach the server')
+  }
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}))
-    throw new Error(errorData?.detail || 'Registration failed')
+    const errorData = await response.json().catch(() => null)
+    const reason = firstErrorMessage(errorData)
+    if (reason) {
+      throw new RegisterError('rejected', reason, response.status)
+    }
+    // No quotable reason means the request never reached DRF (an nginx 502, or
+    // Django's own 400 DisallowedHost page). The status is the only lead left,
+    // and the form appends it to the translated message.
+    throw new RegisterError('server', `Server error (${response.status})`, response.status)
   }
   return await response.json()
 }

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -48,6 +48,8 @@
     },
     "register": {
       "email": "Email",
+      "errorNetwork": "Cannot reach the server — is the API running and reachable?",
+      "errorServer": "Something went wrong on the server. Please try again.",
       "genericError": "Registration failed",
       "loginLink": "Login",
       "password": "Password",

--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -48,6 +48,8 @@
     },
     "register": {
       "email": "Correo electrónico",
+      "errorNetwork": "No se puede contactar con el servidor. ¿Está la API activa y accesible?",
+      "errorServer": "Algo salió mal en el servidor. Inténtalo de nuevo.",
       "genericError": "No se pudo completar el registro",
       "loginLink": "Iniciar sesión",
       "password": "Contraseña",

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -403,6 +403,16 @@ hostname, which the UI reports as a failed signup. Set
 serve the web app and API from *different* origins — then it must match the
 scheme, host, and port you are browsing from.
 
+**Signup says the account already exists (or used to just say "Registration
+failed").** The address is already registered, so use the login page instead of
+signup. Two ways a "fresh" instance already has it: an earlier signup attempt
+actually succeeded, or `FINTRACK_ADMIN_EMAIL` in `.env` bootstrapped that same
+address as the admin account when `migrate` ran. If you no longer have the
+password, reset it with
+`docker compose exec api uv run manage.py changepassword <email>`. Note that
+signup is rate limited (`THROTTLE_REGISTER`, five attempts an hour by default),
+so a burst of retries answers `Request was throttled` for a while afterwards.
+
 **Redirect loop after enabling TLS.** Your proxy is not sending
 `X-Forwarded-Proto: https`, so Django thinks the request is plain HTTP and
 redirects again.


### PR DESCRIPTION
Signing up on a self-hosted instance answered every rejection with the same
"Registration failed" and nothing else - no way to tell a taken address from a
short password from an API that never came up.

Two separate causes, both fixed here:

- register() in apps/web/app/lib/auth.ts read only `detail` off the error body.
  DRF puts validation errors under the field key - {"email": ["..."]},
  {"password": ["..."]} - and only uses `detail` for throttling, so every
  actionable reason fell through to the hardcoded fallback. It now reads both
  shapes, the way the axios client's 400 handler already did.
- The duplicate-email branch answered "Something went wrong. Please contact
  support or try again.", which points at the wrong remedy even once it is
  visible. It now says the account exists and to log in instead. This discloses
  nothing new: a caller already separates a taken address from a free one by the
  status (400 vs 201), and registration stays rate limited.

register() now throws a typed RegisterError, mirroring LoginError next to it, so
the form can localize the network and server cases while showing the server's
own reason verbatim for a rejection - Django has already run that text through
gettext, so it arrives in the user's language.

Verified end to end against a production web build served behind a same-origin
/api/ proxy: a taken address now renders "An account with this email already
exists. Try logging in instead.", a short password renders the password rule.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018FoxYfYcrzMQEKKaFiQpKz